### PR TITLE
Added ability to specify a topic name on a definition.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,20 +74,29 @@ class Plugin {
 		const alarmActions = [];
 		const insufficientDataActions = [];
 
-		if(alertTopics.ok) {
-			okActions.push(alertTopics.ok);
+		
+		if (definition.topics && definition.topics.ok && alertTopics[definition.topics.ok]) {
+			okActions.push(alertTopics[definition.topics.ok]);
+		} else {
+			if(alertTopics.ok) {
+				okActions.push(alertTopics.ok);
+			}
 		}
 
-		if (definition.topic && alertTopics[definition.topic]) {
-			alarmActions.push(alertTopics[definition.topic]);
+		if (definition.topics && definition.topics.alarm && alertTopics[definition.topics.alarm]) {
+			alarmActions.push(alertTopics[definition.topics.alarm]);
 		} else {
 			if(alertTopics.alarm) {
 				alarmActions.push(alertTopics.alarm);
 			}
 		}
 
-		if(alertTopics.insufficientData) {
-			insufficientDataActions.push(alertTopics.insufficientData);
+		if (definition.topics && definition.topics.insufficientData && alertTopics[definition.topics.insufficientData]) {
+			insufficientDataActions.push(alertTopics[definition.topics.insufficientData]);
+		} else {
+			if(alertTopics.insufficientData) {
+				insufficientDataActions.push(alertTopics.insufficientData);
+			}
 		}
 
 		const namespace = definition.pattern ? 

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,12 @@ class Plugin {
 			okActions.push(alertTopics.ok);
 		}
 
-		if(alertTopics.alarm) {
-			alarmActions.push(alertTopics.alarm);
+		if (definition.topic && alertTopics[definition.topic]) {
+			alarmActions.push(alertTopics[definition.topic]);
+		} else {
+			if(alertTopics.alarm) {
+				alarmActions.push(alertTopics.alarm);
+			}
 		}
 
 		if(alertTopics.insufficientData) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -686,5 +686,56 @@ describe('#index', function () {
 				}
 			});
 		});
+
+
+        it('should add actions - with custom topics', () => {
+			const alertTopics = {
+				customOk: 'custom-Ok-topic',
+				customAlarm: 'custom-Alarm-topic',
+				customInsufficientData: 'custom-InsufficientData-topic',
+			};
+
+			const definition = {
+				namespace: 'AWS/Lambda',
+				metric: 'Errors',
+				threshold: 10,
+				statistic: 'Maximum',
+				period: 300,
+				evaluationPeriods: 1,
+				comparisonOperator: 'GreaterThanThreshold',
+				topics: {
+					ok: 'customOk',
+					alarm: 'customAlarm',
+					insufficientData: 'customInsufficientData'
+				}
+
+			};
+
+			const functionRef = 'func-ref';
+
+			const cf = plugin.getAlarmCloudFormation(alertTopics, definition, functionRef);
+
+			expect(cf).toEqual({
+				Type: 'AWS::CloudWatch::Alarm',
+				Properties: {
+					Namespace: definition.namespace,
+					MetricName: definition.metric,
+					Threshold: definition.threshold,
+					Statistic: definition.statistic,
+					Period: definition.period,
+					EvaluationPeriods: definition.evaluationPeriods,
+					ComparisonOperator: definition.comparisonOperator,
+					OKActions: ['custom-Ok-topic'],
+					AlarmActions: ['custom-Alarm-topic'],
+					InsufficientDataActions: ['custom-InsufficientData-topic'],
+					Dimensions: [{
+						Name: 'FunctionName',
+						Value: {
+							Ref: functionRef,
+						}
+					}],
+				}
+			});
+		});
 	})
 });


### PR DESCRIPTION
This is to allow the scenario where you want to escalate when things go really wrong to a different topic.

To do this, add a new topic to the topics section, then add a topic: entry to the definition and specific the topic name.

Working example:
custom:
  notifications:
    - protocol: email
      endpoint: xxxx@yyyyy.slack.com
  codeRedNotifications:
    - protocol: email
      endpoint: 11223344556677@messagenet.com


    topics:
      alarm:
        topic: ${self:service}-${opt:stage, self:provider.stage}-alerts-alarm
        notifications: ${self:custom.notifications}
      codeRed:
        topic: ${self:service}-${opt:stage, self:provider.stage}-alerts-alarm-code-red
        notifications: ${self:custom.codeRedNotifications}



      functionCodeRed:
        namespace: 'AWS/Lambda'
        metric: Errors
        threshold: 5
        statistic: Sum
        period: 300
        evaluationPeriods: 1
        comparisonOperator: GreaterThanOrEqualToThreshold
        topic: codeRed


