### PR TITLE
Set default comparison operators to "GreaterThanOrEqualToThreshold"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ custom:
         statistic: Average
         period: 300
         evaluationPeriods: 1
-        comparisonOperator: GreaterThanThreshold
+        comparisonOperator: GreaterThanOrEqualToThreshold
     alarms:
       - functionThrottles
       - functionErrors
@@ -62,7 +62,7 @@ functions:
         statistic: Minimum
         period: 60
         evaluationPeriods: 1
-        comparisonOperator: GreaterThanThreshold
+        comparisonOperator: GreaterThanOrEqualToThreshold
 ```
 
 ## SNS Topics
@@ -133,7 +133,7 @@ definitions:
     statistic: Sum
     period: 60
     evaluationPeriods: 1
-    comparisonOperator: GreaterThanThreshold
+    comparisonOperator: GreaterThanOrEqualToThreshold
     treatMissingData: missing
   functionErrors:
     namespace: 'AWS/Lambda'
@@ -142,7 +142,7 @@ definitions:
     statistic: Maximum
     period: 60
     evaluationPeriods: 1
-    comparisonOperator: GreaterThanThreshold
+    comparisonOperator: GreaterThanOrEqualToThreshold
     treatMissingData: missing
   functionDuration:
     namespace: 'AWS/Lambda'
@@ -151,7 +151,7 @@ definitions:
     statistic: Maximum
     period: 60
     evaluationPeriods: 1
-    comparisonOperator: GreaterThanThreshold
+    comparisonOperator: GreaterThanOrEqualToThreshold
     treatMissingData: missing
   functionThrottles:
     namespace: 'AWS/Lambda'
@@ -160,7 +160,7 @@ definitions:
     statistic: Sum
     period: 60
     evaluationPeriods: 1
-    comparisonOperator: GreaterThanThreshold
+    comparisonOperator: GreaterThanOrEqualToThreshold
     treatMissingData: missing
 ```
 

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -10,7 +10,7 @@ module.exports = {
     statistic: 'Sum',
     period: 60,
     evaluationPeriods: 1,
-    comparisonOperator: 'GreaterThanThreshold',
+    comparisonOperator: 'GreaterThanOrEqualToThreshold',
   },
   functionErrors: {
     namespace: lambdaNamespace,
@@ -19,7 +19,7 @@ module.exports = {
     statistic: 'Sum',
     period: 60,
     evaluationPeriods: 1,
-    comparisonOperator: 'GreaterThanThreshold',
+    comparisonOperator: 'GreaterThanOrEqualToThreshold',
   },
   functionDuration: {
     namespace: lambdaNamespace,
@@ -28,7 +28,7 @@ module.exports = {
     statistic: 'Average',
     period: 60,
     evaluationPeriods: 1,
-    comparisonOperator: 'GreaterThanThreshold',
+    comparisonOperator: 'GreaterThanOrEqualToThreshold',
   },
   functionThrottles: {
     namespace: lambdaNamespace,
@@ -37,6 +37,6 @@ module.exports = {
     statistic: 'Sum',
     period: 60,
     evaluationPeriods: 1,
-    comparisonOperator: 'GreaterThanThreshold',
+    comparisonOperator: 'GreaterThanOrEqualToThreshold',
   }
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -158,7 +158,7 @@ describe('#index', function () {
             statistic: 'Maximum',
             period: 300,
             evaluationPeriods: 1,
-            comparisonOperator: 'GreaterThanThreshold',
+            comparisonOperator: 'GreaterThanOrEqualToThreshold',
           },
           customDefinition: {
             namespace: 'AWS/Lambda',
@@ -167,7 +167,7 @@ describe('#index', function () {
             statistic: 'Minimum',
             period: 120,
             evaluationPeriods: 2,
-            comparisonOperator: 'GreaterThanThreshold',
+            comparisonOperator: 'GreaterThanOrEqualToThreshold',
           }
         }
       };
@@ -183,7 +183,7 @@ describe('#index', function () {
           statistic: 'Sum',
           period: 60,
           evaluationPeriods: 1,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         },
         functionErrors: {
           namespace: 'AWS/Lambda',
@@ -192,7 +192,7 @@ describe('#index', function () {
           statistic: 'Maximum',
           period: 300,
           evaluationPeriods: 1,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         },
         functionDuration: {
           namespace: 'AWS/Lambda',
@@ -201,7 +201,7 @@ describe('#index', function () {
           statistic: 'Average',
           period: 60,
           evaluationPeriods: 1,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         },
         functionThrottles: {
           namespace: 'AWS/Lambda',
@@ -210,7 +210,7 @@ describe('#index', function () {
           statistic: 'Sum',
           period: 60,
           evaluationPeriods: 1,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         },
         customDefinition: {
           namespace: 'AWS/Lambda',
@@ -219,7 +219,7 @@ describe('#index', function () {
           statistic: 'Minimum',
           period: 120,
           evaluationPeriods: 2,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         }
       });
     });
@@ -235,7 +235,7 @@ describe('#index', function () {
           statistic: 'Minimum',
           period: 120,
           evaluationPeriods: 2,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         }
       },
       global: ['functionThrottles'],
@@ -279,7 +279,7 @@ describe('#index', function () {
         statistic: 'Minimum',
         period: 120,
         evaluationPeriods: 2,
-        comparisonOperator: 'GreaterThanThreshold',
+        comparisonOperator: 'GreaterThanOrEqualToThreshold',
       }]);
     });
 
@@ -295,7 +295,7 @@ describe('#index', function () {
           statistic: 'Minimum',
           period: 120,
           evaluationPeriods: 2,
-          comparisonOperator: 'GreaterThanThreshold',
+          comparisonOperator: 'GreaterThanOrEqualToThreshold',
         }]
       }, config, definitions);
 
@@ -307,7 +307,7 @@ describe('#index', function () {
         statistic: 'Minimum',
         period: 120,
         evaluationPeriods: 2,
-        comparisonOperator: 'GreaterThanThreshold',
+        comparisonOperator: 'GreaterThanOrEqualToThreshold',
       }]);
     });
 
@@ -432,7 +432,7 @@ describe('#index', function () {
             Statistic: 'Sum',
             Period: 60,
             EvaluationPeriods: 1,
-            ComparisonOperator: 'GreaterThanThreshold',
+            ComparisonOperator: 'GreaterThanOrEqualToThreshold',
             AlarmActions: [],
             OKActions: [],
             InsufficientDataActions: [],
@@ -456,7 +456,7 @@ describe('#index', function () {
             statistic: 'Sum',
             period: 60,
             evaluationPeriods: 1,
-            comparisonOperator: 'GreaterThanThreshold',
+            comparisonOperator: 'GreaterThanOrEqualToThreshold',
             pattern: '{$.level > 40}'
           }
         },
@@ -480,7 +480,7 @@ describe('#index', function () {
             Statistic: 'Sum',
             Period: 60,
             EvaluationPeriods: 1,
-            ComparisonOperator: 'GreaterThanThreshold',
+            ComparisonOperator: 'GreaterThanOrEqualToThreshold',
             OKActions: [],
             AlarmActions: [],
             InsufficientDataActions: [],
@@ -630,7 +630,7 @@ describe('#index', function () {
         statistic: 'Maximum',
         period: 300,
         evaluationPeriods: 1,
-        comparisonOperator: 'GreaterThanThreshold',
+        comparisonOperator: 'GreaterThanOrEqualToThreshold',
         treatMissingData: 'breaching',
       };
 


### PR DESCRIPTION
## What did you implement:

I changed the default `comparisonOperator` from `GreaterThanThreshold` to `GreaterThanOrEqualToThreshold`. For me, it was counter-intuitive for the `functionErrors` and `functionThrottles` alerts to need 2+ errors or throttles in a given period. It seems as if I string up the monitoring for errors and throttles, I'd be concerned about _any_ errors or throttles, or I would set a higher threshold if I had different requirements.

I changed the defaults for `functionInvocations` and `functionDuration` as well just to make it consistent across them. Since they have higher thresholds, it's unlikely to have as much of an effect -- the difference between 100 and 101 invocations is much different than the difference between 0 and 1 errors.

Feel free to ignore and close if you disagree with these new defaults 😄. It was surprising to me, but perhaps I'm an outlier. Either way, thanks for this plugin -- very helpful!

