### PR TITLE
Fix the metrics for api-gw latency and requests widgets, which were swapped

### DIFF
--- a/src/dashboards/widgets/api-gw/latency/time-series.js
+++ b/src/dashboards/widgets/api-gw/latency/time-series.js
@@ -14,9 +14,10 @@ const createWidget = (config) => {
       view: 'timeSeries',
       stacked: false,
       metrics: [
-          [ 'AWS/ApiGateway', '5XXError', 'ApiName', apiName, { stat: 'Sum', period: 900 } ],
-          [ 'AWS/ApiGateway', '4XXError', 'ApiName', apiName, { stat: 'Sum', period: 900 } ],
-          [ 'AWS/ApiGateway', 'Count', 'ApiName', apiName, { stat: 'Sum', period: 900 } ]
+          [ 'AWS/ApiGateway', 'IntegrationLatency', 'ApiName', apiName, { stat: 'p50', period: 900, region: config.region } ],
+          [ 'AWS/ApiGateway', 'Latency', 'ApiName', apiName, { stat: 'p50', period: 900, region: config.region } ],
+          [ 'AWS/ApiGateway', 'IntegrationLatency', 'ApiName', apiName, { stat: 'p90', period: 900, region: config.region } ],
+          [ 'AWS/ApiGateway', 'Latency', 'ApiName', apiName, { stat: 'p90', period: 900, region: config.region } ]
       ],
       region: config.region,
     }

--- a/src/dashboards/widgets/api-gw/requests/time-series.js
+++ b/src/dashboards/widgets/api-gw/requests/time-series.js
@@ -14,10 +14,9 @@ const createWidget = (config) => {
       view: 'timeSeries',
       stacked: false,
       metrics: [
-          [ 'AWS/ApiGateway', 'IntegrationLatency', 'ApiName', apiName, { stat: 'p50', period: 900, region: config.region } ],
-          [ 'AWS/ApiGateway', 'Latency', 'ApiName', apiName, { stat: 'p50', period: 900, region: config.region } ],
-          [ 'AWS/ApiGateway', 'IntegrationLatency', 'ApiName', apiName, { stat: 'p90', period: 900, region: config.region } ],
-          [ 'AWS/ApiGateway', 'Latency', 'ApiName', apiName, { stat: 'p90', period: 900, region: config.region } ]
+          [ 'AWS/ApiGateway', '5XXError', 'ApiName', apiName, { stat: 'Sum', period: 900 } ],
+          [ 'AWS/ApiGateway', '4XXError', 'ApiName', apiName, { stat: 'Sum', period: 900 } ],
+          [ 'AWS/ApiGateway', 'Count', 'ApiName', apiName, { stat: 'Sum', period: 900 } ]
       ],
       region: config.region,
     }


### PR DESCRIPTION
## What did you implement:

API Gateway widgets had the wrong metrics and need to be swapped. This PR does that swap.

## How did you implement it:

Just swapped the metrics from api-gw latency to api-gw requests, and vice-versa

## How can we verify it:

Before:
<img width="694" alt="screen shot 2017-07-19 at 2 46 40 pm" src="https://user-images.githubusercontent.com/1191967/28384012-243f0808-6c91-11e7-9628-978837382dfc.png">

After:
<img width="691" alt="screen shot 2017-07-19 at 2 46 19 pm" src="https://user-images.githubusercontent.com/1191967/28384025-2d07cff6-6c91-11e7-81ad-424659c9e7a4.png">


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

