### PR TITLE
Allow specifying template(s) to use for dashboard(s)

### DIFF
--- a/src/dashboards/configs/vertical.json
+++ b/src/dashboards/configs/vertical.json
@@ -1,0 +1,144 @@
+{
+    "widgets": [
+      {
+        "title": "Errors",
+        "service": "lambda",
+        "metric": "errors",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 0,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Errors",
+        "service": "lambda",
+        "metric": "errors",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 0,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Duration",
+        "service": "lambda",
+        "metric": "duration",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 6,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Duration Average",
+        "service": "lambda",
+        "metric": "duration",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 6,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Invocations",
+        "service": "lambda",
+        "metric": "invocations",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 12,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Invocations",
+        "service": "lambda",
+        "metric": "invocations",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 12,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Iterator Age",
+        "service": "lambda",
+        "metric": "iteratorage",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 18,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Iterator Age Average",
+        "service": "lambda",
+        "metric": "iteratorage",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 18,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Throttles",
+        "service": "lambda",
+        "metric": "throttles",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 24,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "Throttles",
+        "service": "lambda",
+        "metric": "throttles",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 24,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "API Latency",
+        "service": "api-gw",
+        "metric": "latency",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 30,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "API Latency Average",
+        "service": "api-gw",
+        "metric": "latency",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 30,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "API Requests",
+        "service": "api-gw",
+        "metric": "requests",
+        "display": "time-series",
+        "coordinates": {
+          "x": 0, "y": 36,
+          "width": 10, "height": 6
+        }
+      },
+      {
+        "title": "API Requests",
+        "service": "api-gw",
+        "metric": "requests",
+        "display": "numbers",
+        "coordinates": {
+          "x": 10, "y": 36,
+          "width": 10, "height": 6
+        }
+      }
+    ]
+}

--- a/src/dashboards/index.js
+++ b/src/dashboards/index.js
@@ -4,6 +4,7 @@ const widgetFactory = require('./widgets/factory');
 
 const dashboards = {
   'default': require('./configs/default'),
+  'vertical': require('./configs/vertical'),
 };
 
 const createDashboard = (service, stage, region, functions, name) => {

--- a/src/dashboards/widgets/api-gw/latency/numbers.js
+++ b/src/dashboards/widgets/api-gw/latency/numbers.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const createWidget = (config) => {
+  const apiName = `${config.stage}-${config.service}`;
+
+  const widget = {
+    type: 'metric',
+    x: config.coordinates.x,
+    y: config.coordinates.y,
+    width: config.coordinates.width,
+    height: config.coordinates.height,
+    properties: {
+      title: config.title,
+      view: 'singleValue',
+      metrics: [
+        [ 'AWS/ApiGateway', 'IntegrationLatency', 'ApiName', apiName, { stat: 'Average', period: 2592000, region: config.region, label: 'IntegrationLatency' } ],
+        [ 'AWS/ApiGateway', 'Latency', 'ApiName', apiName, { stat: 'Average', period: 2592000, region: config.region, label: 'Latency' } ]
+      ],
+      region: config.region,
+      period: 300
+    }
+  };
+
+  return widget;
+};
+
+module.exports = {
+  createWidget,
+};

--- a/src/dashboards/widgets/api-gw/requests/numbers.js
+++ b/src/dashboards/widgets/api-gw/requests/numbers.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const createWidget = (config) => {
+  const apiName = `${config.stage}-${config.service}`;
+
+  const widget = {
+    type: 'metric',
+    x: config.coordinates.x,
+    y: config.coordinates.y,
+    width: config.coordinates.width,
+    height: config.coordinates.height,
+    properties: {
+      title: config.title,
+      view: 'singleValue',
+      metrics: [
+        [ 'AWS/ApiGateway', '5XXError', 'ApiName', apiName, { stat: 'Sum', period: 2592000, region: config.region, label: '5XXError' } ],
+        [ 'AWS/ApiGateway', '4XXError', 'ApiName', apiName, { stat: 'Sum', period: 2592000, region: config.region, label: '4XXError' } ],
+        [ 'AWS/ApiGateway', 'Count', 'ApiName', apiName, { stat: 'Sum', period: 2592000, region: config.region, label: 'Count' } ]
+      ],
+      region: config.region,
+      period: 300
+    }
+  };
+
+  return widget;
+};
+
+module.exports = {
+  createWidget,
+};

--- a/src/dashboards/widgets/factory.js
+++ b/src/dashboards/widgets/factory.js
@@ -3,14 +3,17 @@
 const widgets = {
   'api-gw': {
     latency: {
+      'numbers': require('./api-gw/latency/numbers'),
       'time-series': require('./api-gw/latency/time-series'),
     },
     requests: {
+      'numbers': require('./api-gw/requests/numbers'),
       'time-series': require('./api-gw/requests/time-series'),
     },
   },
   lambda: {
     duration: {
+      'numbers': require('./lambda/duration/numbers'),
       'time-series': require('./lambda/duration/time-series'),
     },
     errors: {
@@ -24,6 +27,10 @@ const widgets = {
     throttles: {
       'numbers': require('./lambda/throttles/numbers'),
       'time-series': require('./lambda/throttles/time-series'),
+    },
+    iteratorage: {
+      'numbers': require('./lambda/iterator-age/numbers'),
+      'time-series': require('./lambda/iterator-age/time-series'),
     },
   },
 };

--- a/src/dashboards/widgets/lambda/duration/numbers.js
+++ b/src/dashboards/widgets/lambda/duration/numbers.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const createWidget = (config) => {
+  const widget = {
+    type: 'metric',
+    x: config.coordinates.x,
+    y: config.coordinates.y,
+    width: config.coordinates.width,
+    height: config.coordinates.height,
+    properties: {
+      title: config.title,
+      view: 'singleValue',
+      metrics: [ ],
+      region: config.region,
+      period: 300
+    }
+  };
+
+  widget.properties.metrics = config.functions.map(f => ([
+    'AWS/Lambda',
+    'Duration',
+    'FunctionName',
+    `${config.service}-${config.stage}-${f.name}`,
+    {
+      stat: 'Average',
+      period: 2592000,
+      region: config.region,
+      label: f.name
+    }
+  ]));
+
+  return widget;
+};
+
+module.exports = {
+  createWidget,
+};

--- a/src/dashboards/widgets/lambda/iterator-age/numbers.js
+++ b/src/dashboards/widgets/lambda/iterator-age/numbers.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const createWidget = (config) => {
+  const widget = {
+    type: 'metric',
+    x: config.coordinates.x,
+    y: config.coordinates.y,
+    width: config.coordinates.width,
+    height: config.coordinates.height,
+    properties: {
+      title: config.title,
+      view: 'singleValue',
+      metrics: [ ],
+      region: config.region,
+      period: 300
+    }
+  };
+
+  widget.properties.metrics = config.functions.map(f => ([
+    'AWS/Lambda',
+    'IteratorAge',
+    'FunctionName',
+    `${config.service}-${config.stage}-${f.name}`,
+    {
+      stat: 'Average',
+      period: 2592000,
+      region: config.region,
+      label: f.name
+    }
+  ]));
+
+  return widget;
+};
+
+module.exports = {
+  createWidget,
+};

--- a/src/dashboards/widgets/lambda/iterator-age/time-series.js
+++ b/src/dashboards/widgets/lambda/iterator-age/time-series.js
@@ -17,18 +17,33 @@ const createWidget = (config) => {
     }
   };
 
-  widget.properties.metrics = config.functions.map(f => ([
-    'AWS/Lambda',
-    'IteratorAge',
-    'FunctionName',
-    `${config.service}-${config.stage}-${f.name}`,
-    {
-      stat: 'Sum',
-      period: 900,
-      region: config.region,
-      label: f.name
-    }
-  ]));
+  widget.properties.metrics = config.functions.reduce((accum, f) => {
+    return accum.concat([
+      [
+        'AWS/Lambda',
+        'IteratorAge',
+        'FunctionName',
+        `${config.service}-${config.stage}-${f.name}`,
+        {
+          stat: 'p50',
+          period: 900,
+          region: config.region,
+          label: `${f.name} p50`,
+        }
+      ],[
+        'AWS/Lambda',
+        'IteratorAge',
+        'FunctionName',
+        `${config.service}-${config.stage}-${f.name}`,
+        {
+          stat: 'p90',
+          period: 900,
+          region: config.region,
+          label: `${f.name} p90`,
+        }
+      ]
+    ]);
+  }, []);
 
   return widget;
 };


### PR DESCRIPTION
## What did you implement:

Make dashboards config accept template name(s) as a value. Can be an array if you want to create multiple dashboards.  Default dashboard is used if true is passed as value, and all dashboards that are not default, append the template name to the DashboardName. Add vertical template to include IteratorAge (p50 and p90 timeline, avg for numbers) and add numbers widgets for api-gw latency (avg), api-gw requests (sum), and lambda duration (avg). Vertical layout thas one metric per row, split evenly for the timeline and numbers widgets to show more data.

## How did you implement it:

pass the dashboards config to the compileDashboards function, if true then use default, otherwise make an array of dashboard templates passed and enumerate them to create the dashboard and add to cfResources. Created vertical template and added numbers widgets for the metrics that didn't have them, ensure all lambda and api-gw widgets were in the vertical dashboard, and that each metric split the two widgets (timeline and numbers) evenly across the row.

## How can we verify it:

deploy a service with this plugin with dashboards set to the array of 'default' and 'vertical', record some activity in the service, and then view the dashboard in Cloudwatch to see the new layout and widgets

default:
<img width="1666" alt="screen shot 2017-07-20 at 11 57 04 am" src="https://user-images.githubusercontent.com/1191967/28427174-53e51784-6d43-11e7-94a4-6758fc4b0a93.png">

vertical:
<img width="1503" alt="screen shot 2017-07-20 at 11 59 47 am" src="https://user-images.githubusercontent.com/1191967/28427180-5b4f3d88-6d43-11e7-8ed6-295a74912248.png">

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Provide verification config/commands/resources

