### PR TITLE
Added an ability to overwrite alarm definitions per function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ functions:
     handler: foo.handler
     alarms: # merged with function alarms
       - customAlarm
-      - name: fooAlarm
+      - name: fooAlarm # creates new alarm or overwrites some properties of the alarm (with the same name) from definitions
         namespace: 'AWS/Lambda'
         metric: errors # define custom metrics here
         threshold: 1

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class Plugin {
           name: alarm
         }));
       } else if (_.isObject(alarm)) {
-        result.push(alarm);
+        result.push(_.merge({}, definitions[alarm.name], alarm));
       }
 
       return result;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -106,6 +106,27 @@ describe('#index', function () {
         plugin.getAlarms(alarms, definitions);
       }).toThrow();
     });
+
+    it('should merge alarm with definition', () => {
+      const testAlarm = {
+        name: 'testAlarm',
+        threshold: 100
+      };
+      const alarms = [testAlarm];
+      const definitions = {
+        testAlarm: {
+          threshold: 1,
+          statistic: 'Sum'
+        }
+      };
+
+      const alarmsConfig = plugin.getAlarms(alarms, definitions);
+      expect(alarmsConfig).toEqual([{
+        name: 'testAlarm',
+        threshold: 100,
+        statistic: 'Sum'
+      }]);
+    });
   });
 
   describe('#getGlobalAlarms', () => {


### PR DESCRIPTION
## What did you implement:

Sometimes it's needed to be able to tweak alarms for some functions (e.g. throttling threshold).

## How did you implement it:

Syntax remains the same, but logic was tweaked to merging alarm definition from function level with a globally defined one.

## How can we verify it:

Use the following service definition:
```yaml
custom:
  alerts:
    topics:
      alarm: 'alarm-topic'
    definitions:
      functionErrors:
        threshold: 1
    alarms:
      - functionErrors

functions:
  foo:
    handler: foo.handler
  bar:
    handler: bar.handler
    alarms:
      - name: functionErrors
        threshold: 100
```

After packaging service, check that both functions have `functionErrors` alarm, but threshold for `foo` is 1, while for `bar` - 100.

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

