### PR TITLE
Fix typo of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ provider:
 custom:
   alerts:
     stages: # Optionally - select which stages to deploy alarms to
-      - producton
+      - production
       - staging
 
     dashboards: true


### PR DESCRIPTION
## What did you implement:
Fixed typos found in README.

producton ->
production


