### PR TITLE
[Security] Upgrade Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serverless": "^1.12.0"
   },
   "dependencies": {
-    "lodash": "^4.16.6"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
     "coveralls": "^2.11.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,9 +1742,13 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
+
+lodash@^4.17.10:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 lodash@^4.17.4:
   version "4.17.4"


### PR DESCRIPTION
I came to this project and noticed this warning on the repo:

<img width="553" alt="screen_shot_2018-07-06_at_13_39_54" src="https://user-images.githubusercontent.com/630449/42390400-1fd4bbf4-8122-11e8-920b-285c33fea567.png">


It's complaining about this lodash security issue: https://nodesecurity.io/advisories/577

## What did you implement:

Used `yarn upgrade-interactive` to upgrade the version of lodash.

## How did you implement it:

N/A

## How can we verify it:

Ensure that lodash uses still work - the tests still pass.

