### PR TITLE
Change the setting of jest from the default to execute the *.test.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "eslint-plugin-promise": "^3.4.1",
     "eslint-plugin-standard": "^2.0.1",
     "jest": "^19.0.2"
+  },
+  "jest": {
+    "testMatch": ["<rootDir>/src/**/*.test.js"]
   }
 }


### PR DESCRIPTION
## What did you implement:

Added jest setting to run test according to the project's configuration

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

I git clone and run the test and found the following points

- The test file of the project is different from the default rule of jest
- There is no setting for jest, jest is looking for the default `__tests__`

As a result it will be `No tests found`

```
$ $(npm bin)/jest
No tests found
  33 files checked.
  roots: /Users/sakamotoakira/.ghq/github.com/sakamossan/serverless-plugin-aws-alerts - 33 matches
  testMatch: **/__tests__/**/*.js?(x),**/?(*.)(spec|test).js?(x) - 0 matches
  testPathIgnorePatterns: /node_modules/ - 33 matches
```

> How did you implement it

I looked it up here

- [Configuring Jest#testMatch](https://jestjs.io/docs/ja/configuration#testmatch-array-string)

Can you merge if package.json settings do not conflict with your development environment
Or you would like me to tell you the test commands you are using regularly 🙏 

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

You should be able to confirm by clone and running the test

```bash
$ git clone git@github.com:sakamossan/serverless-plugin-aws-alerts.git
$ yarn run test
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

Please let me know if there are things to do in the missing parts

- [x] Write tests
- [ ] Write documentation
- [x] Fix linting errors
- [ ] Provide verification config/commands/resources
