### PR TITLE
Refrence a topic from Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,26 @@ functions:
 
 If topic name is specified, plugin assumes that topic does not exist and will create it. To use existing topics, specify ARNs instead.
 
+You can also reference a topic defined in the resources:
+
+```yaml
+custom: 
+  alerts:
+    topics:
+      alarm:
+        Ref: SNSTopic
+
+resources:
+  Resources:
+    SNSTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: ${self:service}-${opt:stage}
+        Subscription:
+          - Endpoint: me@example.com
+            Protocol: EMAIL
+```
+
 ## SNS Notifications
 
 You can configure subscriptions to your SNS topics within your `serverless.yml`. For each subscription, you'll need to specify a `protocol` and an `endpoint`.

--- a/src/index.js
+++ b/src/index.js
@@ -156,22 +156,29 @@ class AlertsPlugin {
       Object.keys(config.topics).forEach((key) => {
         const topicConfig = config.topics[key];
         const isTopicConfigAnObject = _.isObject(topicConfig);
+        const isTopConfigARef = isTopicConfigAnObject && topicConfig.Ref;
 
-        const topic = isTopicConfigAnObject ? topicConfig.topic : topicConfig;
-        const notifications = isTopicConfigAnObject ? topicConfig.notifications : [];
+        if (isTopConfigARef) {
+          alertTopics[key] = {
+            Ref: topicConfig.Ref
+          };
+        } else {
+          const topic = isTopicConfigAnObject ? topicConfig.topic : topicConfig;
+          const notifications = isTopicConfigAnObject ? topicConfig.notifications : [];
 
-        if (topic) {
-          if (topic.indexOf('arn:') === 0) {
-            alertTopics[key] = topic;
-          } else {
-            const cfRef = `AwsAlerts${_.upperFirst(key)}`;
-            alertTopics[key] = {
-              Ref: cfRef
-            };
+          if (topic) {
+            if (topic.indexOf('arn:') === 0) {
+              alertTopics[key] = topic;
+            } else {
+              const cfRef = `AwsAlerts${_.upperFirst(key)}`;
+              alertTopics[key] = {
+                Ref: cfRef
+              };
 
-            this.addCfResources({
-              [cfRef]: this.getSnsTopicCloudFormation(topic, notifications),
-            });
+              this.addCfResources({
+                [cfRef]: this.getSnsTopicCloudFormation(topic, notifications),
+              });
+            }
           }
         }
       });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -363,6 +363,28 @@ describe('#index', function () {
       expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
     });
 
+    it('should not create SNS topic when Ref is passed', () => {
+      const topicRef = 'MySNSResource';
+      const plugin = pluginFactory({
+        topics: {
+          ok: {
+            Ref: topicRef
+          }
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: {
+          Ref: topicRef
+        }
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
+
     it('should create SNS topic when name is passed', () => {
       const topicName = 'ok-topic';
       const plugin = pluginFactory({


### PR DESCRIPTION
## What did you implement:

Closes #68 

Being able to reference a topic defined as a CloudFormation template in from resources.

## How did you implement it:

In the previous code, the topic could be either a String (the name of the topic or the ARN) or an object.

In the case of an object, it was assumed that the value was a String (the name of the topic or the ARN).

In both cases, the topic was only created if the given string was not an ARN.

I've added a case where the topic can also be a Ref in which case I `Ref` the name of the resource without creating the topic.

## How can we verify it:

I've added the appropriate unit test (line 366, `should not create SNS topic when Ref is passed`)

You can also try it with the following config:

```yaml
custom: 
  alerts:
    topics:
      ok:
        Ref: SNSTopic
      alarm:
        Ref: SNSTopic
      insufficientData:
        Ref: SNSTopic

resources:
  Resources:
    SNSTopic:
      Type: AWS::SNS::Topic
      Properties:
        DisplayName: ${self:service}-${opt:stage}
        Subscription:
          - Endpoint: me@example.com
            Protocol: EMAIL
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

