### PR TITLE
#76 support ImportValue from CloudFormation exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,28 @@ functions:
 
 ## SNS Topics
 
-If topic name is specified, plugin assumes that topic does not exist and will create it. To use existing topics, specify ARNs instead.
+If topic name is specified, plugin assumes that topic does not exist and will create it. To use existing topics, specify ARNs or use Fn::ImportValue to use a topic exported with CloudFormation.
+
+#### ARN support
+
+```yaml
+custom:
+  alerts:
+    topics:
+      alarm:
+        topic: arn:aws:sns:${self:region}:${self::accountId}:monitoring-${opt:stage}
+```
+
+#### Import support
+
+```yaml
+custom:
+  alerts:
+    topics:
+      alarm:
+        topic:
+          Fn::ImportValue: ServiceMonitoring:monitoring-${opt:stage, 'dev'}
+```
 
 ## SNS Notifications
 

--- a/src/index.js
+++ b/src/index.js
@@ -156,12 +156,13 @@ class AlertsPlugin {
       Object.keys(config.topics).forEach((key) => {
         const topicConfig = config.topics[key];
         const isTopicConfigAnObject = _.isObject(topicConfig);
+        const isTopicConfigAnImport = isTopicConfigAnObject && topicConfig['Fn::ImportValue'];
 
-        const topic = isTopicConfigAnObject ? topicConfig.topic : topicConfig;
-        const notifications = isTopicConfigAnObject ? topicConfig.notifications : [];
+        const topic = isTopicConfigAnObject && !isTopicConfigAnImport ? topicConfig.topic : topicConfig;
+        const notifications = isTopicConfigAnObject && !isTopicConfigAnImport ? topicConfig.notifications : [];
 
         if (topic) {
-          if (topic.indexOf('arn:') === 0) {
+          if (isTopicConfigAnImport || topic.indexOf('arn:') === 0) {
             alertTopics[key] = topic;
           } else {
             const cfRef = `AwsAlerts${_.upperFirst(key)}`;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -127,6 +127,15 @@ describe('#index', function () {
         statistic: 'Sum'
       }]);
     });
+
+    it('should import alarms from CloudFormation', () => {
+      const testAlarm = { 'Fn::ImportValue': "ServiceMonitoring:monitoring-${opt:stage, 'dev'}" };
+      const alarms = [testAlarm];
+      const definitions = {};
+
+      const alarmsConfig = plugin.getAlarms(alarms, definitions);
+      expect(alarmsConfig).toEqual([testAlarm]);
+    });
   });
 
   describe('#getGlobalAlarms', () => {


### PR DESCRIPTION
## What did you implement:

Closes #76

## How did you implement it:
Handle objects with Fn::ImportValue property by simply passing it through.

## How can we verify it:
See documentation. Create a CF Stack with an exported SNS topic and import it with
```yaml
custom:
  alerts:
    topics:
      alarm:
        topic:
          Fn::ImportValue: ServiceMonitoring:monitoring-${opt:stage, 'dev'}
```

## Todos:

- [v] Write tests
- [v] Write documentation
- [v] Fix linting errors
- [v] Provide verification config/commands/resources

