### PR TITLE
#78 Ability to create alarm on a dimension of a metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,26 @@ definitions:
     comparisonOperator: GreaterThanOrEqualToThreshold
     treatMissingData: missing
 ```
+## Additional dimensions
+
+The plugin allows users to provide custom dimensions for the alarm. Dimensions are provided in a list of key/value pairs {Name: foo, Value:bar} 
+The plugin will always apply dimension of {Name: FunctionName, Value: ((FunctionName))}
+ For example:
+ 
+```yaml
+    alarms: # merged with function alarms
+      - name: fooAlarm
+        namespace: 'AWS/Lambda'
+        metric: errors # define custom metrics here
+        threshold: 1
+        statistic: Minimum
+        period: 60
+        evaluationPeriods: 1
+        comparisonOperator: GreaterThanThreshold
+        dimensions:
+          -  Name: foo
+             Value: bar
+```
 
 ## Using Percentile Statistic for a Metric
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ The plugin will always apply dimension of {Name: FunctionName, Value: ((Function
              Value: bar
 ```
 
+```json
+'Dimensions': [
+                {
+                    'Name': 'foo',
+                    'Value': 'bar'
+                },
+            ]
+```
+
 ## Using Percentile Statistic for a Metric
 
 Statistic not only supports SampleCount, Average, Sum, Minimum or Maximum as defined in CloudFormation [here](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-statistic), but also percentiles. This is possible by leveraging  [ExtendedStatistic](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-extendedstatistic) under the hood. This plugin will automatically choose the correct key for you. See an example below:

--- a/src/index.js
+++ b/src/index.js
@@ -98,12 +98,7 @@ class AlertsPlugin {
       this.naming.getPatternMetricName(definition.metric, functionRef) :
       definition.metric;
 
-    const dimensions = definition.pattern ? [] : [{
-      Name: 'FunctionName',
-      Value: {
-        Ref: functionRef,
-      }
-    }];
+    const dimensions = definition.pattern ? []: this.naming.getDimensionsList(definition.dimensions, functionRef);
 
     const treatMissingData = definition.treatMissingData ? definition.treatMissingData : 'missing';
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -748,7 +748,7 @@ describe('#index', function () {
         evaluationPeriods: 1,
         comparisonOperator: 'GreaterThanThreshold',
         treatMissingData: 'breaching',
-        dimensions: [{'Cow': 'MOO', 'Duck':'QUACK'}]
+        dimensions: [{'Name':'Cow', 'Value':'MOO'}, {'Name':'Duck', 'Value':'QUACK'}]
       };
 
       const functionRef = 'func-ref';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -748,7 +748,7 @@ describe('#index', function () {
         evaluationPeriods: 1,
         comparisonOperator: 'GreaterThanThreshold',
         treatMissingData: 'breaching',
-        dimensions: {'Cow': 'MOO', 'Duck':'QUACK'}
+        dimensions: [{'Cow': 'MOO', 'Duck':'QUACK'}]
       };
 
       const functionRef = 'func-ref';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -731,5 +731,59 @@ describe('#index', function () {
         }
       });
     });
+    it('should allow user to provide custom dimensions', () => {
+      const alertTopics = {
+        ok: 'ok-topic',
+        alarm: 'alarm-topic',
+        insufficientData: 'insufficientData-topic',
+      };
+
+      const definition = {
+        description: 'An error alarm',
+        namespace: 'AWS/Lambda',
+        metric: 'Errors',
+        threshold: 1,
+        statistic: 'p95',
+        period: 300,
+        evaluationPeriods: 1,
+        comparisonOperator: 'GreaterThanThreshold',
+        treatMissingData: 'breaching',
+        dimensions: {'Cow': 'MOO', 'Duck':'QUACK'}
+      };
+
+      const functionRef = 'func-ref';
+
+      const cf = plugin.getAlarmCloudFormation(alertTopics, definition, functionRef);
+
+      expect(cf).toEqual({
+        Type: 'AWS::CloudWatch::Alarm',
+        Properties: {
+          AlarmDescription: definition.description,
+          Namespace: definition.namespace,
+          MetricName: definition.metric,
+          Threshold: definition.threshold,
+          ExtendedStatistic: definition.statistic,
+          Period: definition.period,
+          EvaluationPeriods: definition.evaluationPeriods,
+          ComparisonOperator: definition.comparisonOperator,
+          OKActions: ['ok-topic'],
+          AlarmActions: ['alarm-topic'],
+          InsufficientDataActions: ['insufficientData-topic'],
+          Dimensions: [{
+            Name: "Cow",
+            Value: "MOO"
+            },{
+            Name: "Duck",
+            Value: "QUACK"
+            },{
+            Name: 'FunctionName',
+            Value: {
+              Ref: functionRef,
+            }
+          }],
+          TreatMissingData: 'breaching',
+        }
+      });
+    });    
   })
 });

--- a/src/naming.js
+++ b/src/naming.js
@@ -6,8 +6,6 @@ const getNormalisedName = (name) => {
   return `${_.upperFirst(name.replace(/-/g, 'Dash').replace(/_/g, 'Underscore'))}`;
 }
 
-const FUNCTION_NAME_KEY = 'FunctionName';
-
 class Naming {
 
   getAlarmCloudFormationRef(alarmName, prefix) {
@@ -26,7 +24,6 @@ class Naming {
   }
 
   getDimensionsList(dimensionsList, funcRef) {
-    let dimensionsOut = new Array();
     let funcNameDimension =  {
       'Name': 'FunctionName',
       'Value': {

--- a/src/naming.js
+++ b/src/naming.js
@@ -25,26 +25,30 @@ class Naming {
     return `${_.upperFirst(metricName)}${functionName}`;
   }
 
-  getDimensionsList(dimensionsMap, funcRef) {
-    let dimensionsList = new Array();
+  getDimensionsList(dimensionsList, funcRef) {
+    let dimensionsOut = new Array();
     let funcNameDimension =  {
       'Name': 'FunctionName',
       'Value': {
         Ref: funcRef
       }
     };
-    if(dimensionsMap == null)
+    if(dimensionsList == null) {
       return [funcNameDimension];
-    Object.keys(dimensionsMap).forEach((key) => {
-      if(key != FUNCTION_NAME_KEY) {
-        dimensionsList.push({
-          'Name': key,
-          'Value': dimensionsMap[key]
-        });
-      }
-    });
+    }
+    dimensionsList.forEach( (dim) => {
+      Object.keys(dim).forEach((key) => {
+        if(key != FUNCTION_NAME_KEY) {
+          dimensionsOut.push({
+            'Name': key,
+            'Value': dim[key]
+          });
+        }
+      });      
+    })
 
-    return [...dimensionsList, funcNameDimension]
+
+    return [...dimensionsOut, funcNameDimension]
   }
 
 }

--- a/src/naming.js
+++ b/src/naming.js
@@ -37,7 +37,6 @@ class Naming {
       return dim.Name != 'FunctionName'
     })
     filteredDimensions.push(funcNameDimension);
-    console.log(filteredDimensions)
     return filteredDimensions
   }
 

--- a/src/naming.js
+++ b/src/naming.js
@@ -6,6 +6,8 @@ const getNormalisedName = (name) => {
   return `${_.upperFirst(name.replace(/-/g, 'Dash').replace(/_/g, 'Underscore'))}`;
 }
 
+const FUNCTION_NAME_KEY = 'FunctionName';
+
 class Naming {
 
   getAlarmCloudFormationRef(alarmName, prefix) {
@@ -21,6 +23,28 @@ class Naming {
 
   getPatternMetricName(metricName, functionName) {
     return `${_.upperFirst(metricName)}${functionName}`;
+  }
+
+  getDimensionsList(dimensionsMap, funcRef) {
+    let dimensionsList = new Array();
+    let funcNameDimension =  {
+      'Name': 'FunctionName',
+      'Value': {
+        Ref: funcRef
+      }
+    };
+    if(dimensionsMap == null)
+      return [funcNameDimension];
+    Object.keys(dimensionsMap).forEach((key) => {
+      if(key != FUNCTION_NAME_KEY) {
+        dimensionsList.push({
+          'Name': key,
+          'Value': dimensionsMap[key]
+        });
+      }
+    });
+
+    return [...dimensionsList, funcNameDimension]
   }
 
 }

--- a/src/naming.js
+++ b/src/naming.js
@@ -36,19 +36,10 @@ class Naming {
     if(dimensionsList == null) {
       return [funcNameDimension];
     }
-    dimensionsList.forEach( (dim) => {
-      Object.keys(dim).forEach((key) => {
-        if(key != FUNCTION_NAME_KEY) {
-          dimensionsOut.push({
-            'Name': key,
-            'Value': dim[key]
-          });
-        }
-      });      
+    let filteredDimensions = dimensionsList.filter( (dim) => {
+      return dim.Name != 'FunctionName'
     })
-
-
-    return [...dimensionsOut, funcNameDimension]
+    return [...filteredDimensions, funcNameDimension]
   }
 
 }

--- a/src/naming.js
+++ b/src/naming.js
@@ -36,7 +36,9 @@ class Naming {
     let filteredDimensions = dimensionsList.filter( (dim) => {
       return dim.Name != 'FunctionName'
     })
-    return [...filteredDimensions, funcNameDimension]
+    filteredDimensions.push(funcNameDimension);
+    console.log(filteredDimensions)
+    return filteredDimensions
   }
 
 }

--- a/src/naming.test.js
+++ b/src/naming.test.js
@@ -35,4 +35,21 @@ describe('#naming', function () {
       expect(actual).toEqual(expected);
     });
   });
+
+  describe('#getDimensionsMap', () => {
+    let naming = null;
+    beforeEach( () => naming = new Naming());
+
+    it('should use function name derived from funcref', () => {
+      const expected = [{"Name":"Duck", "Value":"QUACK"}, {"Name":"FunctionName", "Value": {'Ref': 'funcName'}}]
+      const actual = naming.getDimensionsList({'FunctionName':'overridden', 'Duck':'QUACK'}, 'funcName')
+      expect(actual).toEqual(expected);
+    });
+
+    it('should get a mapped dimensions object when FunctionName is missing', () => {
+      const expected = [{"Name":"Duck", "Value":"QUACK"}, {"Name":"FunctionName", "Value":{'Ref': 'funcName'}}]
+      const actual = naming.getDimensionsList({'Duck':'QUACK'}, 'funcName');
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/src/naming.test.js
+++ b/src/naming.test.js
@@ -42,13 +42,13 @@ describe('#naming', function () {
 
     it('should use function name derived from funcref', () => {
       const expected = [{"Name":"Duck", "Value":"QUACK"}, {"Name":"FunctionName", "Value": {'Ref': 'funcName'}}]
-      const actual = naming.getDimensionsList([{'FunctionName':'overridden'},{'Duck':'QUACK'}], 'funcName')
+      const actual = naming.getDimensionsList([{'Name':'FunctionName', 'Value':'overridden'},{'Name':'Duck', 'Value':'QUACK'}], 'funcName')
       expect(actual).toEqual(expected);
     });
 
     it('should get a mapped dimensions object when FunctionName is missing', () => {
       const expected = [{"Name":"Duck", "Value":"QUACK"}, {"Name":"FunctionName", "Value":{'Ref': 'funcName'}}]
-      const actual = naming.getDimensionsList([{'Duck':'QUACK'}], 'funcName');
+      const actual = naming.getDimensionsList([{'Name':'Duck', 'Value':'QUACK'}], 'funcName');
       expect(actual).toEqual(expected);
     });
   });

--- a/src/naming.test.js
+++ b/src/naming.test.js
@@ -42,13 +42,13 @@ describe('#naming', function () {
 
     it('should use function name derived from funcref', () => {
       const expected = [{"Name":"Duck", "Value":"QUACK"}, {"Name":"FunctionName", "Value": {'Ref': 'funcName'}}]
-      const actual = naming.getDimensionsList({'FunctionName':'overridden', 'Duck':'QUACK'}, 'funcName')
+      const actual = naming.getDimensionsList([{'FunctionName':'overridden'},{'Duck':'QUACK'}], 'funcName')
       expect(actual).toEqual(expected);
     });
 
     it('should get a mapped dimensions object when FunctionName is missing', () => {
       const expected = [{"Name":"Duck", "Value":"QUACK"}, {"Name":"FunctionName", "Value":{'Ref': 'funcName'}}]
-      const actual = naming.getDimensionsList({'Duck':'QUACK'}, 'funcName');
+      const actual = naming.getDimensionsList([{'Duck':'QUACK'}], 'funcName');
       expect(actual).toEqual(expected);
     });
   });


### PR DESCRIPTION
## What did you implement:

Closes #78
Ability to create alarm on a dimension of a metric

## How did you implement it:

Adding the ability to parse a list of dimensions provided in the serverless yml for an alert. The FunctionName dimension will always be added by default, and be taken from the built cloud formation template.

## How can we verify it:

Run serverless deploy with dimensions list of key/values like mentioned in the README update. The generated alarm should be tagged with your custom dimensions in addition to the FunctionName

```yml
        dimensions:
          -  Name: foo
             Value: bar
```

## Todos:

- [ X ] Write tests
- [ X ] Write documentation
- [ X ] Fix linting errors
- [ X ] Provide verification config/commands/resources

