### PR TITLE
Allow using object as SNS Topic value

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ functions:
 
 If topic name is specified, plugin assumes that topic does not exist and will create it. To use existing topics, specify ARNs instead.
 
+You can also use an object that will eventually resolve into an arn of an existing topic:
+
+```yaml
+custom: 
+  alerts:
+    topics:
+      alarm:
+        Fn::Join:
+          - ':'
+          - - arn:aws:sns
+            - Ref: AWS::Region
+            - Ref: AWS::AccountId
+            - ${self:service}-${opt:stage}
+      ok:
+        Ref: SNSTopic
+      insufficientData:
+        topic:
+          Ref: SNSTopic
+
+resources:
+  Resources:
+    SNSTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: ${self:service}-${opt:stage}
+        Subscription:
+          - Endpoint: me@example.com
+            Protocol: EMAIL
+```
+
 ## SNS Notifications
 
 You can configure subscriptions to your SNS topics within your `serverless.yml`. For each subscription, you'll need to specify a `protocol` and an `endpoint`.

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ class AlertsPlugin {
         const notifications = isTopicConfigAnObject ? topicConfig.notifications : [];
 
         if (topic) {
-          if (topic.indexOf('arn:') === 0) {
+          if (_.isObject(topic) || topic.indexOf('arn:') === 0) {
             alertTopics[key] = topic;
           } else {
             const cfRef = `AwsAlerts${_.upperFirst(key)}`;
@@ -173,6 +173,9 @@ class AlertsPlugin {
               [cfRef]: this.getSnsTopicCloudFormation(topic, notifications),
             });
           }
+        }
+        else if (isTopicConfigAnObject) {
+          alertTopics[key] = topicConfig;
         }
       });
     }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -363,6 +363,106 @@ describe('#index', function () {
       expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
     });
 
+    it('should not create SNS topic when an object including Fn::Join is passed', () => {
+      const topic = {
+        'Fn::Join': [
+          ':',
+          [
+            'arn:aws:sns',
+            '${self:provider.region}',
+            {Ref: 'AWS::AccountId'},
+            'ok-topic'
+          ]
+        ],
+      }
+      const plugin = pluginFactory({
+        topics: {
+          ok: topic
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: topic
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
+
+    it('should not create SNS topic when an object including Ref is passed', () => {
+      const topic = {
+        Ref: 'OkTopicLogicalId',
+      }
+      const plugin = pluginFactory({
+        topics: {
+          ok: topic
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: topic
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
+
+    it('should not create SNS topic when an object including Fn::Join is passed under "topic"', () => {
+      const topic = {
+        'Fn::Join': [
+          ':',
+          [
+            'arn:aws:sns',
+            '${self:provider.region}',
+            {Ref: 'AWS::AccountId'},
+            'ok-topic'
+          ]
+        ],
+      }
+      const plugin = pluginFactory({
+        topics: {
+          ok: {
+            topic
+          }
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: topic
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
+
+    it('should not create SNS topic when an object including Ref is passed under "topic"', () => {
+      const topic = {
+        Ref: 'OkTopicLogicalId',
+      }
+      const plugin = pluginFactory({
+        topics: {
+          ok: {
+            topic
+          }
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: topic
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
+
     it('should create SNS topic when name is passed', () => {
       const topicName = 'ok-topic';
       const plugin = pluginFactory({


### PR DESCRIPTION
## What did you implement:

Closes #76

Allows specifying topic as an object that eventually resolves to an arn, instead of a plain string.

## How can we verify it:

Example:
```yaml
custom: 
  alerts:
    topics:
      alarm:
        Fn::Join:
          - ':'
          - - arn:aws:sns
            - Ref: AWS::Region
            - Ref: AWS::AccountId
            - ${self:service}-${opt:stage}
      ok:
        Ref: SNSTopic
      insufficientData:
        topic:
          Ref: SNSTopic
resources:
  Resources:
    SNSTopic:
      Type: AWS::SNS::Topic
      Properties:
        DisplayName: ${self:service}-${opt:stage}
        Subscription:
          - Endpoint: me@example.com
            Protocol: EMAIL
```


## Todos:

- [ ] Write tests
- [ ] Provide verification config/commands/resources

