### PR TITLE
Allow multiple topic definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,19 @@ custom:
     topics:
       critical:
         ok:
-          topic: ${self:service}-${self:custom.stage}-critical-alerts-ok
+          topic: ${self:service}-${opt:stage}-critical-alerts-ok
           notifications:
           - protocol: https
             endpoint: https://events.pagerduty.com/integration/.../enqueue
         alarm:
-          topic: ${self:service}-${self:custom.stage}-critical-alerts-alarm
+          topic: ${self:service}-${opt:stage}-critical-alerts-alarm
           notifications:
           - protocol: https
             endpoint: https://events.pagerduty.com/integration/.../enqueue
 
       nonCritical:
         alarm:
-          topic: ${self:service}-${self:custom.stage}-nonCritical-alerts-alarm
+          topic: ${self:service}-${opt:stage}-nonCritical-alerts-alarm
           notifications:
           - protocol: email
             endpoint: alarms@email.com

--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,21 @@ class AlertsPlugin {
       insufficientDataActions.push(alertTopics.insufficientData);
     }
 
+    if (definition.okActions) {
+    _.flatten(definition.okActions)
+            .map( alertTopic => {okActions.push(alertTopics[alertTopic].ok)});
+    }
+
+    if (definition.alarmActions) {
+      _.flatten(definition.alarmActions)
+              .map( alertTopic => {alarmActions.push(alertTopics[alertTopic].alarm)});
+    }
+
+    if (definition.insufficientDataActions) {
+      _.flatten(definition.insufficientDataActions)
+              .map( alertTopic => {insufficientDataActions.push(alertTopics[alertTopic].insufficientData)});
+    }
+
     const namespace = definition.pattern ?
       this.awsProvider.naming.getStackName() :
       definition.namespace;

--- a/src/index.js
+++ b/src/index.js
@@ -91,18 +91,15 @@ class AlertsPlugin {
     }
 
     if (definition.okActions) {
-    _.flatten(definition.okActions)
-            .map( alertTopic => {okActions.push(alertTopics[alertTopic].ok)});
+      definition.okActions.map( alertTopic => {okActions.push(alertTopics[alertTopic].ok)});
     }
 
     if (definition.alarmActions) {
-      _.flatten(definition.alarmActions)
-              .map( alertTopic => {alarmActions.push(alertTopics[alertTopic].alarm)});
+      definition.alarmActions.map( alertTopic => {alarmActions.push(alertTopics[alertTopic].alarm)});
     }
 
     if (definition.insufficientDataActions) {
-      _.flatten(definition.insufficientDataActions)
-              .map( alertTopic => {insufficientDataActions.push(alertTopics[alertTopic].insufficientData)});
+      definition.insufficientDataActions.map( alertTopic => {insufficientDataActions.push(alertTopics[alertTopic].insufficientData)});
     }
 
     const namespace = definition.pattern ?

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -447,6 +447,74 @@ describe('#index', function () {
         }
       });
     });
+
+    it('should create SNS topic with nested definitions', () => {
+      const plugin = pluginFactory({
+        topics: {
+          critical: {
+            ok: 'critical-ok-topic',
+            alert: 'critical-alert-topic',
+            insufficientData: 'critical-insufficientData-topic'
+          },
+          nonCritical: {
+            alarm: 'nonCritical-alarm-topic'
+          }
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        critical: {
+          ok: {
+            Ref: `AwsAlertsCriticalOk`
+          },
+      alert: {
+        Ref: `AwsAlertsCriticalAlert`
+      },
+      insufficientData: {
+        Ref: `AwsAlertsCriticalInsufficientData`
+      }
+        },
+        nonCritical: {
+          alarm: {
+            Ref: `AwsAlertsNonCriticalAlarm`
+          }
+        }
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({
+        'AwsAlertsCriticalOk': {
+          Type: 'AWS::SNS::Topic',
+          Properties: {
+            TopicName: 'critical-ok-topic',
+            Subscription: [],
+          }
+        },
+        'AwsAlertsCriticalAlert': {
+          Type: 'AWS::SNS::Topic',
+          Properties: {
+            TopicName: 'critical-alert-topic',
+            Subscription: [],
+          }
+        },
+        'AwsAlertsCriticalInsufficientData': {
+          Type: 'AWS::SNS::Topic',
+          Properties: {
+            TopicName: 'critical-insufficientData-topic',
+            Subscription: [],
+          }
+        },
+        'AwsAlertsNonCriticalAlarm': {
+          Type: 'AWS::SNS::Topic',
+          Properties: {
+            TopicName: 'nonCritical-alarm-topic',
+            Subscription: [],
+          }
+        }
+      });
+    });
   });
 
   describe('#compileAlarms', () => {


### PR DESCRIPTION
Allow multiple topic definitions.

We allowed an array in definition of topics - basically its a refactor of current method for creating a topic, only we apply it for all items in topic array.

All examples and motivation is in updated readme, examples and tests.

Everything backward compatible.