### PR TITLE
Support for AnomalyDetection Alarms and disabling alarms per-function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ functions:
         comparisonOperator: GreaterThanOrEqualToThreshold
 ```
 
+## Anomaly Detection Alarms
+
+You can create alarms using [CloudWatch AnomalyDetection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html) to alarm when data is outside a number of standard deviations of normal, rather than at a static threshold.
+When using anomaly detection alarms the threshold property specifies the "Anomaly Detection Threshold" seen in the AWS console.
+
+```yaml
+functions:
+  bar:
+    handler: bar.handler
+    alarms:
+      - name: barAlarm
+        type: anomalyDetection
+        namespace: 'AWS/Lamabda'
+        metric: Invocations
+        threshold: 2
+        statistic: Sum
+        period: 60
+        evaluationPeriods: 1
+        datapointsToAlarm: 1
+        comparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
+```
+
 ## Multiple topic definitions
 
 You can define several topics for alarms. For example you want to have topics for critical alarms

--- a/README.md
+++ b/README.md
@@ -306,6 +306,29 @@ definitions:
     comparisonOperator: GreaterThanOrEqualToThreshold
     treatMissingData: missing
 ```
+
+## Disabling default alarms for specific functions
+
+Default alarms can be disabled on a per-function basis:
+
+```yaml
+custom:
+  alerts:
+    alarms:
+      - functionThrottles
+      - functionErrors
+      - functionInvocations
+      - functionDuration
+
+functions:
+  bar:
+    handler: bar.handler
+    alarms:
+      - name: functionInvocations
+        enabled: false
+
+```
+
 ## Additional dimensions
 
 The plugin allows users to provide custom dimensions for the alarm. Dimensions are provided in a list of key/value pairs {Name: foo, Value:bar}

--- a/README.md
+++ b/README.md
@@ -77,12 +77,14 @@ functions:
 You can create alarms using [CloudWatch AnomalyDetection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html) to alarm when data is outside a number of standard deviations of normal, rather than at a static threshold.
 When using anomaly detection alarms the threshold property specifies the "Anomaly Detection Threshold" seen in the AWS console.
 
+Default alarms can also be updated to be anomaly detection alarms by adding the `type: anomalyDetection` property.
+
 ```yaml
 functions:
-  bar:
-    handler: bar.handler
+  foo:
+    handler: foo.handler
     alarms:
-      - name: barAlarm
+      - name: fooAlarm
         type: anomalyDetection
         namespace: 'AWS/Lamabda'
         metric: Invocations
@@ -91,6 +93,17 @@ functions:
         period: 60
         evaluationPeriods: 1
         datapointsToAlarm: 1
+        comparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
+  bar:
+    handler: bar.handler
+    alarms:
+      - name: functionErrors
+        threshold: 2
+        type: anomalyDetection
+        comparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
+      - name: functionInvocations
+        threshold: 2
+        type: anomalyDetection
         comparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
 ```
 

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -5,6 +5,8 @@ const lambdaNamespace = 'AWS/Lambda';
 module.exports = {
   functionInvocations: {
     namespace: lambdaNamespace,
+    enabled: true,
+    type: 'static',
     metric: 'Invocations',
     threshold: 100,
     statistic: 'Sum',
@@ -15,6 +17,8 @@ module.exports = {
   },
   functionErrors: {
     namespace: lambdaNamespace,
+    enabled: true,
+    type: 'static',
     metric: 'Errors',
     threshold: 1,
     statistic: 'Sum',
@@ -25,6 +29,8 @@ module.exports = {
   },
   functionDuration: {
     namespace: lambdaNamespace,
+    enabled: true,
+    type: 'static',
     metric: 'Duration',
     threshold: 500,
     statistic: 'Average',
@@ -35,6 +41,8 @@ module.exports = {
   },
   functionThrottles: {
     namespace: lambdaNamespace,
+    enabled: true,
+    type: 'static',
     metric: 'Throttles',
     threshold: 1,
     statistic: 'Sum',

--- a/src/index.js
+++ b/src/index.js
@@ -65,9 +65,9 @@ class AlertsPlugin {
     if (!config) throw new Error('Missing config argument');
     if (!definitions) throw new Error('Missing definitions argument');
 
-    const alarms = functionObj.alarms.filter(alarm => {
+    const alarms = functionObj.alarms ? functionObj.alarms.filter(alarm => {
       return typeof alarm.enabled === "undefined" || alarm.enabled;
-    });
+    }) : functionObj.alarms;
     return this.getAlarms(alarms, definitions);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class AlertsPlugin {
         result.push(Object.assign(
           {
             enabled: true,
-            type: "static"
+            type: 'static'
           },
           definition,
           {
@@ -55,7 +55,7 @@ class AlertsPlugin {
         result.push(_.merge(
           {
             enabled: true,
-            type: "static"
+            type: 'static'
           },
           definitions[alarm.name],
           alarm)
@@ -133,7 +133,7 @@ class AlertsPlugin {
 
     const statisticValues = ['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum'];
     let alarm;
-    if (definition.type === "static") {
+    if (definition.type === 'static') {
       alarm = {
         Type: 'AWS::CloudWatch::Alarm',
         Properties: {
@@ -158,7 +158,7 @@ class AlertsPlugin {
       } else {
         alarm.Properties.ExtendedStatistic = definition.statistic
       }
-    } else if (definition.type === "anomalyDetection") {
+    } else if (definition.type === 'anomalyDetection') {
       alarm = {
         Type: 'AWS::CloudWatch::Alarm',
         Properties: {
@@ -172,7 +172,7 @@ class AlertsPlugin {
           InsufficientDataActions: insufficientDataActions,
           Metrics: [
             {
-              Id: "m1",
+              Id: 'm1',
               ReturnData: true,
               MetricStat: {
                 Namespace: namespace,
@@ -183,12 +183,13 @@ class AlertsPlugin {
               }
             },
             {
-              Id: "ad1",
+              Id: 'ad1',
               Expression: `ANOMALY_DETECTION_BAND(m1, ${definition.threshold})`,
               Label: `${metricId} (expected)`,
               ReturnData: true
             }
-          ]
+          ],
+          ThresholdMetricId: 'ad1'
         }
       }
     } else {
@@ -206,36 +207,6 @@ class AlertsPlugin {
         stackName
       });
     }
-
-    /*
-        AuthorizerFunctionInvocationsAlarm:
-          Type: AWS::CloudWatch::Alarm
-          Properties:
-            EvaluationPeriods: 1
-            DatapointsToAlarm: 1
-            ComparisonOperator: LessThanLowerOrGreaterThanUpperThreshold
-            TreatMissingData: missing
-            Metrics:
-              - Id: m1
-                ReturnData: true
-                MetricStat:
-                  Metric:
-                    Namespace: AWS/Lambda
-                    MetricName: Invocations
-                    Dimensions:
-                      - Name: FunctionName
-                        Value:
-                          Ref: AuthorizerLambdaFunction
-                  Period: 60
-                  Stat: Sum
-              - Id: ad1
-                Expression: ANOMALY_DETECTION_BAND(m1, 2)
-                Label: "Invocations (expected)"
-                ReturnData: true
-            ThresholdMetricId: ad1
-            AlarmActions:
-              - arn:aws:sns:us-east-2:#{AWS::AccountId}:developer_alerts
-    */
     return alarm;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -175,9 +175,11 @@ class AlertsPlugin {
               Id: 'm1',
               ReturnData: true,
               MetricStat: {
-                Namespace: namespace,
-                MetricName: metricId,
-                Dimensions: dimensions,
+                Metric: {
+                  Namespace: namespace,
+                  MetricName: metricId,
+                  Dimensions: dimensions
+                },
                 Period: definition.period,
                 Stat: definition.statistic
               }

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,9 @@ class AlertsPlugin {
     if (!config) throw new Error('Missing config argument');
     if (!definitions) throw new Error('Missing definitions argument');
 
-    const alarms = functionObj.alarms;
+    const alarms = functionObj.alarms.filter(alarm => {
+      return typeof alarm.enabled === "undefined" || alarm.enabled;
+    });
     return this.getAlarms(alarms, definitions);
   }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1248,14 +1248,16 @@ describe('#index', function () {
               Id: 'm1',
               ReturnData: true,
               MetricStat: {
-                Namespace: definition.namespace,
-                MetricName: definition.metric,
-                Dimensions: [{
-                  Name: 'FunctionName',
-                  Value: {
-                    Ref: functionRef,
-                  }
-                }],
+                Metric: {
+                  Namespace: definition.namespace,
+                  MetricName: definition.metric,
+                  Dimensions: [{
+                    Name: 'FunctionName',
+                    Value: {
+                      Ref: functionRef,
+                    }
+                  }]
+                },
                 Period: definition.period,
                 Stat: definition.statistic
               }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -86,12 +86,16 @@ describe('#index', function () {
       const alarmsConfig = plugin.getAlarms(alarms, definitions);
       expect(alarmsConfig).toEqual([{
         name: 'test',
-        enabled: true
+        enabled: true,
+        type: 'static'
       }]);
     });
 
     it('should get alarms config by object', () => {
-      const testAlarm = { enabled: true };
+      const testAlarm = {
+        enabled: true,
+        type: 'static'
+      };
       const alarms = [testAlarm];
       const definitions = {};
 
@@ -125,6 +129,7 @@ describe('#index', function () {
       expect(alarmsConfig).toEqual([{
         name: 'testAlarm',
         enabled: true,
+        type: 'static',
         threshold: 100,
         statistic: 'Sum'
       }]);
@@ -133,7 +138,8 @@ describe('#index', function () {
     it('should import alarms from CloudFormation', () => {
       const testAlarm = {
         'Fn::ImportValue': "ServiceMonitoring:monitoring-${opt:stage, 'dev'}",
-        enabled: true
+        enabled: true,
+        type: 'static'
       };
       const alarms = [testAlarm];
       const definitions = {};
@@ -188,6 +194,7 @@ describe('#index', function () {
       const config = {
         definitions: {
           functionErrors: {
+            type: 'static',
             metric: 'Errors',
             threshold: 1,
             statistic: 'Maximum',
@@ -197,6 +204,8 @@ describe('#index', function () {
             comparisonOperator: 'GreaterThanOrEqualToThreshold',
           },
           customDefinition: {
+            type: 'static',
+            enabled: true,
             namespace: 'AWS/Lambda',
             metric: 'Invocations',
             threshold: 5,
@@ -215,6 +224,8 @@ describe('#index', function () {
       expect(actual).toEqual({
         functionInvocations: {
           namespace: 'AWS/Lambda',
+          type: 'static',
+          enabled: true,
           metric: 'Invocations',
           threshold: 100,
           statistic: 'Sum',
@@ -225,6 +236,8 @@ describe('#index', function () {
         },
         functionErrors: {
           namespace: 'AWS/Lambda',
+          type: 'static',
+          enabled: true,
           metric: 'Errors',
           threshold: 1,
           statistic: 'Maximum',
@@ -235,6 +248,8 @@ describe('#index', function () {
         },
         functionDuration: {
           namespace: 'AWS/Lambda',
+          type: 'static',
+          enabled: true,
           metric: 'Duration',
           threshold: 500,
           statistic: 'Average',
@@ -245,6 +260,8 @@ describe('#index', function () {
         },
         functionThrottles: {
           namespace: 'AWS/Lambda',
+          type: 'static',
+          enabled: true,
           metric: 'Throttles',
           threshold: 1,
           statistic: 'Sum',
@@ -255,6 +272,8 @@ describe('#index', function () {
         },
         customDefinition: {
           namespace: 'AWS/Lambda',
+          type: 'static',
+          enabled: true,
           metric: 'Invocations',
           threshold: 5,
           statistic: 'Minimum',
@@ -317,6 +336,7 @@ describe('#index', function () {
       expect(actual).toEqual([{
         name: 'customAlarm',
         enabled: true,
+        type: 'static',
         namespace: 'AWS/Lambda',
         metric: 'Invocations',
         threshold: 5,
@@ -348,6 +368,7 @@ describe('#index', function () {
       expect(actual).toEqual([{
         name: 'fooAlarm',
         enabled: true,
+        type: 'static',
         namespace: 'AWS/Lambda',
         metric: 'Invocations',
         threshold: 5,
@@ -920,6 +941,8 @@ describe('#index', function () {
 
       const definition = {
         description: 'An error alarm',
+        type: 'static',
+        name: 'test-alarm',
         namespace: 'AWS/Lambda',
         metric: 'Errors',
         threshold: 1,
@@ -977,6 +1000,8 @@ describe('#index', function () {
 
       const definition = {
         description: 'An error alarm',
+        type: 'static',
+        name: 'test-alarm',
         namespace: 'AWS/Lambda',
         metric: 'Errors',
         threshold: 1,
@@ -1030,6 +1055,8 @@ describe('#index', function () {
 
       const definition = {
         description: 'An error alarm',
+        type: 'static',
+        name: 'test-alarm',
         namespace: 'AWS/Lambda',
         metric: 'Errors',
         threshold: 1,
@@ -1078,6 +1105,8 @@ describe('#index', function () {
 
       const definition = {
         description: 'An error alarm',
+        type: 'static',
+        name: 'test-alarm',
         namespace: 'AWS/Lambda',
         metric: 'Errors',
         threshold: 1,
@@ -1134,6 +1163,8 @@ describe('#index', function () {
       const definition = {
         nameTemplate: '$[functionName]-$[functionId]-$[metricName]-$[metricId]',
         description: 'An error alarm',
+        type: 'static',
+        name: 'test-alarm',
         namespace: 'AWS/Lambda',
         metric: 'Errors',
         threshold: 1,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1220,7 +1220,7 @@ describe('#index', function () {
         metric: 'Errors',
         threshold: 1,
         period: 300,
-        statistic: "Sum",
+        statistic: 'Sum',
         datapointsToAlarm: 1,
         evaluationPeriods: 1,
         comparisonOperator: 'GreaterThanThreshold',
@@ -1245,7 +1245,7 @@ describe('#index', function () {
           InsufficientDataActions: ['insufficientData-topic'],
           Metrics: [
             {
-              Id: "m1",
+              Id: 'm1',
               ReturnData: true,
               MetricStat: {
                 Namespace: definition.namespace,
@@ -1261,12 +1261,13 @@ describe('#index', function () {
               }
             },
             {
-              Id: "ad1",
+              Id: 'ad1',
               Expression: `ANOMALY_DETECTION_BAND(m1, ${definition.threshold})`,
               Label: `${definition.metric} (expected)`,
               ReturnData: true
             }
-          ]
+          ],
+          ThresholdMetricId: 'ad1'
         }
       });
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -86,11 +86,12 @@ describe('#index', function () {
       const alarmsConfig = plugin.getAlarms(alarms, definitions);
       expect(alarmsConfig).toEqual([{
         name: 'test',
+        enabled: true
       }]);
     });
 
     it('should get alarms config by object', () => {
-      const testAlarm = {};
+      const testAlarm = { enabled: true };
       const alarms = [testAlarm];
       const definitions = {};
 
@@ -123,13 +124,17 @@ describe('#index', function () {
       const alarmsConfig = plugin.getAlarms(alarms, definitions);
       expect(alarmsConfig).toEqual([{
         name: 'testAlarm',
+        enabled: true,
         threshold: 100,
         statistic: 'Sum'
       }]);
     });
 
     it('should import alarms from CloudFormation', () => {
-      const testAlarm = { 'Fn::ImportValue': "ServiceMonitoring:monitoring-${opt:stage, 'dev'}" };
+      const testAlarm = {
+        'Fn::ImportValue': "ServiceMonitoring:monitoring-${opt:stage, 'dev'}",
+        enabled: true
+      };
       const alarms = [testAlarm];
       const definitions = {};
 
@@ -311,6 +316,7 @@ describe('#index', function () {
 
       expect(actual).toEqual([{
         name: 'customAlarm',
+        enabled: true,
         namespace: 'AWS/Lambda',
         metric: 'Invocations',
         threshold: 5,
@@ -341,6 +347,7 @@ describe('#index', function () {
 
       expect(actual).toEqual([{
         name: 'fooAlarm',
+        enabled: true,
         namespace: 'AWS/Lambda',
         metric: 'Invocations',
         threshold: 5,
@@ -470,12 +477,12 @@ describe('#index', function () {
           ok: {
             Ref: `AwsAlertsCriticalOk`
           },
-      alert: {
-        Ref: `AwsAlertsCriticalAlert`
-      },
-      insufficientData: {
-        Ref: `AwsAlertsCriticalInsufficientData`
-      }
+          alert: {
+            Ref: `AwsAlertsCriticalAlert`
+          },
+          insufficientData: {
+            Ref: `AwsAlertsCriticalInsufficientData`
+          }
         },
         nonCritical: {
           alarm: {
@@ -630,7 +637,7 @@ describe('#index', function () {
       });
     });
 
-    it('should use globally defined nameTemplate when it`s not provided in definitions', function() {
+    it('should use globally defined nameTemplate when it`s not provided in definitions', function () {
       let config = {
         nameTemplate: '$[functionName]-global',
         function: ['functionErrors']
@@ -671,7 +678,7 @@ describe('#index', function () {
       });
     });
 
-    it('should use globally defined prefixTemplate when it`s not provided in definitions', function() {
+    it('should use globally defined prefixTemplate when it`s not provided in definitions', function () {
       let config = {
         nameTemplate: '$[functionName]-global',
         prefixTemplate: 'notTheStackName',
@@ -713,7 +720,7 @@ describe('#index', function () {
       });
     });
 
-    it('should overwrite globally defined nameTemplate using definitions', function() {
+    it('should overwrite globally defined nameTemplate using definitions', function () {
       let config = {
         nameTemplate: '$[functionName]-global',
         definitions: {
@@ -759,7 +766,7 @@ describe('#index', function () {
       });
     });
 
-    it('should overwrite globally defined prefixTemplate using definitions', function() {
+    it('should overwrite globally defined prefixTemplate using definitions', function () {
       let config = {
         nameTemplate: '$[functionName]-global',
         prefixTemplate: 'notTheStackName',
@@ -1079,7 +1086,7 @@ describe('#index', function () {
         evaluationPeriods: 1,
         comparisonOperator: 'GreaterThanThreshold',
         treatMissingData: 'breaching',
-        dimensions: [{'Name':'Cow', 'Value':'MOO'}, {'Name':'Duck', 'Value':'QUACK'}]
+        dimensions: [{ 'Name': 'Cow', 'Value': 'MOO' }, { 'Name': 'Duck', 'Value': 'QUACK' }]
       };
 
       const functionName = 'func-name';
@@ -1104,10 +1111,10 @@ describe('#index', function () {
           Dimensions: [{
             Name: "Cow",
             Value: "MOO"
-            },{
+          }, {
             Name: "Duck",
             Value: "QUACK"
-            },{
+          }, {
             Name: 'FunctionName',
             Value: {
               Ref: functionRef,
@@ -1124,7 +1131,7 @@ describe('#index', function () {
         insufficientData: 'insufficientData-topic',
       };
 
-       const definition = {
+      const definition = {
         nameTemplate: '$[functionName]-$[functionId]-$[metricName]-$[metricId]',
         description: 'An error alarm',
         namespace: 'AWS/Lambda',
@@ -1136,12 +1143,12 @@ describe('#index', function () {
         treatMissingData: 'breaching',
       };
 
-       const functionName = 'func-name';
-       const functionRef = 'func-ref';
+      const functionName = 'func-name';
+      const functionRef = 'func-ref';
 
-       const cf = plugin.getAlarmCloudFormation(alertTopics, definition, functionName, functionRef);
+      const cf = plugin.getAlarmCloudFormation(alertTopics, definition, functionName, functionRef);
 
-       expect(cf).toEqual({
+      expect(cf).toEqual({
         Type: 'AWS::CloudWatch::Alarm',
         Properties: {
           AlarmName: `fooservice-dev-${functionName}-${functionRef}-${definition.metric}-${definition.metric}`,


### PR DESCRIPTION
## What did you implement:

Two features proposed in this PR:

1. Allow disabling an alarm configured as a default on a per-function basis. It is very valuable to define alarms to be applied to each function in my CF stack, but on some occasions some functions should not have the default alarm(s) applied.  This new property allows a default alarm to be disabled for any given function(s).
1. Add support for AnomalyDetection type alarms.  Alarms of this type don't have a static threshold to trigger the alarm.  AWS generates a model based on past data, then a threshold is set for how many standard deviations outside the predicted model a data point must be to trigger the alarm.  This is very useful for functions with invocation patterns that aren't flat, for example.


## How did you implement it:

Trivial implementation changes to add two new properties to alarm definitions:
1. enabled
    1. If enabled is false no CloudFormation resources will be created for this alarm
1. type
    1. 'static' - default value when not specified, maintains existing behavior
    1. 'anomalyDetection' - creates CloudFormation resources to create an "anomaly detection" type alarm

## How can we verify it:

Not sure if anything needs to be provided here?  Examples in the readme demonstrate use, the result will be visible in the CloudWatch console as an alarm using the "anomaly detection" feature.


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources

