### PR TITLE
Prevent error when custom:alerts is undefined

### DIFF
--- a/src/external-stack.js
+++ b/src/external-stack.js
@@ -59,6 +59,13 @@ class ExternalStack {
   }
 
   getExternalStackConfig() {
+    if (!this.serverless.service.custom.alerts) {
+      return (
+        this.options["alerts-external-stack"] ||
+        ""
+      );
+    }
+    
     return (
       this.serverless.service.custom.alerts.externalStack ||
       this.options["alerts-external-stack"] ||


### PR DESCRIPTION
If serverless.service.custom.alerts is null, there should not be an error thrown.

With the new ExternalStack implementation, there was a bug where if no alerts were set up in the Serverless.yml file (custom:alerts is undefined), an error was thrown while running `serverless deploy`.

```
Type Error ---------------------------------------------

  TypeError: Cannot read property 'externalStack' of undefined
      at ExternalStack.getExternalStackConfig (C:\SPMD\ResourceTemplateApi_4592Git\node_modules\serverless-plugin-aws-alerts\src\external-stack.js:63:45)
      at ExternalStack.isUsingExternalStack (C:\SPMD\ResourceTemplateApi_4592Git\node_modules\serverless-plugin-aws-alerts\src\external-stack.js:78:19)
      at ExternalStack.afterDeployGlobal (C:\SPMD\ResourceTemplateApi_4592Git\node_modules\serverless-plugin-aws-alerts\src\external-stack.js:182:15)
      at C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\lib\classes\PluginManager.js:490:55
      at tryCatcher (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\util.js:16:23)
      at Object.gotValue (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\reduce.js:168:18)
      at Object.gotAccum (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\reduce.js:155:25)
      at Object.tryCatcher (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\util.js:16:23)
      at Promise._settlePromiseFromHandler (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\promise.js:547:31)
      at Promise._settlePromise (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\promise.js:604:18)     
      at Promise._settlePromise0 (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\promise.js:649:10)    
      at Promise._settlePromises (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\promise.js:729:18)    
      at _drainQueueStep (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\async.js:93:12)
      at _drainQueue (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\async.js:86:9)
      at Async._drainQueues (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (C:\Users\colin.e.ashburn\AppData\Roaming\nvm\v12.14.1\node_modules\serverless\node_modules\bluebird\js\release\async.js:15:14)
      at processImmediate (internal/timers.js:439:21)
      at process.topLevelDomainCallback (domain.js:130:23)
```

This fixes the error by returning the other options if `custom:alerts` is null.