### PR TITLE
fix: allow metric filters on external stack

### DIFF
--- a/src/external-stack.js
+++ b/src/external-stack.js
@@ -137,6 +137,13 @@ class ExternalStack {
           const refName = resource[key];
           if (!preMergedResources[refName]) {
             if (
+              resource[key].endsWith('LogGroup') &&
+              parent[childKey].Type === 'AWS::Logs::MetricFilter'
+            ) {
+              // Metric filters targetting serverless generated LogGroup resource
+              // should be merged after removing DependsOn property
+              delete parent[childKey].DependsOn;
+            } else if (
               this.serverless.service.provider.compiledCloudFormationTemplate
                 .Resources[refName]
             ) {


### PR DESCRIPTION
## What did you implement:

When custom metric filter definition is added with `externalStack` set to true, any cloudformation resource with `AWS::Logs::MetricFilter` type are dropped from external stack cloudformation template within `fixLambdaFunctionAndLogGroupReferences` method.

## How did you implement it:

Allows cloudformation resource with `DependsOn` key targetting log group name ending with `LogGroup` (sls resource template name according to [this](https://github.com/serverless/serverless/blob/a8f5278298556f8c6d28dc8f7d3d1f0bf1d0f28a/docs/providers/aws/guide/resources.md#aws-cloudformation-resource-reference)) and resource type `AWS::Logs::MetricFilter` to be merged to cloudformation template after removing `DependsOn` parameter.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources

