### PR TITLE
Add config ActionsEnabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ custom:
       functionErrors:
         period: 300 # override period
       customAlarm:
+        actionsEnabled: false # Indicates whether actions should be executed during any changes to the alarm state. The default is TRUE
         description: 'My custom alarm'
         namespace: 'AWS/Lambda'
         nameTemplate: $[functionName]-Duration-IMPORTANT-Alarm # Optionally - naming template for the alarms, overwrites globally defined one
@@ -63,6 +64,7 @@ functions:
       - customAlarm
       - name: fooAlarm # creates new alarm or overwrites some properties of the alarm (with the same name) from definitions
         namespace: 'AWS/Lambda'
+        actionsEnabled: false
         metric: errors # define custom metrics here
         threshold: 1
         statistic: Minimum

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -6,6 +6,7 @@ module.exports = {
   functionInvocations: {
     namespace: lambdaNamespace,
     enabled: true,
+    actionsEnabled: true,
     type: 'static',
     metric: 'Invocations',
     threshold: 100,
@@ -18,6 +19,7 @@ module.exports = {
   functionErrors: {
     namespace: lambdaNamespace,
     enabled: true,
+    actionsEnabled: true,
     type: 'static',
     metric: 'Errors',
     threshold: 1,
@@ -30,6 +32,7 @@ module.exports = {
   functionDuration: {
     namespace: lambdaNamespace,
     enabled: true,
+    actionsEnabled: true,
     type: 'static',
     metric: 'Duration',
     threshold: 500,
@@ -42,6 +45,7 @@ module.exports = {
   functionThrottles: {
     namespace: lambdaNamespace,
     enabled: true,
+    actionsEnabled: true,
     type: 'static',
     metric: 'Throttles',
     threshold: 1,

--- a/src/index.js
+++ b/src/index.js
@@ -141,6 +141,7 @@ class AlertsPlugin {
       alarm = {
         Type: 'AWS::CloudWatch::Alarm',
         Properties: {
+          ActionsEnabled: definition.actionsEnabled,
           Namespace: namespace,
           MetricName: metricId,
           AlarmDescription: definition.description,
@@ -166,6 +167,7 @@ class AlertsPlugin {
       alarm = {
         Type: 'AWS::CloudWatch::Alarm',
         Properties: {
+          ActionsEnabled: definition.actionsEnabled,
           AlarmDescription: definition.description,
           EvaluationPeriods: definition.evaluationPeriods,
           DatapointsToAlarm: definition.datapointsToAlarm,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -205,6 +205,7 @@ describe('#index', function () {
           },
           customDefinition: {
             type: 'static',
+            actionsEnabled: false,
             enabled: true,
             namespace: 'AWS/Lambda',
             metric: 'Invocations',
@@ -224,6 +225,7 @@ describe('#index', function () {
       expect(actual).toEqual({
         functionInvocations: {
           namespace: 'AWS/Lambda',
+          actionsEnabled: true,
           type: 'static',
           enabled: true,
           metric: 'Invocations',
@@ -236,6 +238,7 @@ describe('#index', function () {
         },
         functionErrors: {
           namespace: 'AWS/Lambda',
+          actionsEnabled: true,
           type: 'static',
           enabled: true,
           metric: 'Errors',
@@ -248,6 +251,7 @@ describe('#index', function () {
         },
         functionDuration: {
           namespace: 'AWS/Lambda',
+          actionsEnabled: true,
           type: 'static',
           enabled: true,
           metric: 'Duration',
@@ -260,6 +264,7 @@ describe('#index', function () {
         },
         functionThrottles: {
           namespace: 'AWS/Lambda',
+          actionsEnabled: true,
           type: 'static',
           enabled: true,
           metric: 'Throttles',
@@ -272,6 +277,7 @@ describe('#index', function () {
         },
         customDefinition: {
           namespace: 'AWS/Lambda',
+          actionsEnabled: false,
           type: 'static',
           enabled: true,
           metric: 'Invocations',
@@ -596,6 +602,7 @@ describe('#index', function () {
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
             Namespace: 'AWS/Lambda',
+            ActionsEnabled: true,
             MetricName: 'Invocations',
             Threshold: 100,
             Statistic: 'Sum',
@@ -707,6 +714,7 @@ describe('#index', function () {
         FooFunctionErrorsAlarm: {
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
+            ActionsEnabled: true,
             AlarmName: 'fooservice-dev-foo-global',
             Namespace: 'AWS/Lambda',
             MetricName: 'Errors',
@@ -749,6 +757,7 @@ describe('#index', function () {
         FooFunctionErrorsAlarm: {
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
+            ActionsEnabled: true,
             AlarmName: 'notTheStackName-foo-global',
             Namespace: 'AWS/Lambda',
             MetricName: 'Errors',
@@ -795,6 +804,7 @@ describe('#index', function () {
         FooFunctionErrorsAlarm: {
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
+            ActionsEnabled: true,
             AlarmName: 'fooservice-dev-foo-local',
             Namespace: 'AWS/Lambda',
             MetricName: 'Errors',
@@ -843,6 +853,7 @@ describe('#index', function () {
         FooFunctionErrorsAlarm: {
           Type: 'AWS::CloudWatch::Alarm',
           Properties: {
+            ActionsEnabled: true,
             AlarmName: 'somethingCompletelyCustom-foo-local',
             Namespace: 'AWS/Lambda',
             MetricName: 'Errors',
@@ -866,7 +877,7 @@ describe('#index', function () {
         }
       });
 	});
-	
+
 	it('should skip alarms that are marked disabled', () => {
 		let config = {
 			definitions: {
@@ -891,6 +902,7 @@ describe('#index', function () {
 			FooFunctionInvocationsAlarm: {
 				Type: 'AWS::CloudWatch::Alarm',
 				Properties: {
+          ActionsEnabled: true,
 					Namespace: 'AWS/Lambda',
 					MetricName: 'Invocations',
 					Threshold: 100,


### PR DESCRIPTION
## What did you implement:

Add config actionsEnabled

## How did you implement it:

Cloudformation config [ActionsEnabled](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-actionsenabled) 

## How can we verify it:

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [x] Provide verification config/commands/resources

