### PR TITLE
Add support for EvaluateLowSampleCountPercentile field on percentile …

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ definitions:
     datapointsToAlarm: 1
     comparisonOperator: GreaterThanThreshold
     treatMissingData: missing
+    evaluateLowSampleCountPercentile: ignore
 ```
 
 ## Using a Separate CloudFormation Stack

--- a/src/index.js
+++ b/src/index.js
@@ -161,6 +161,7 @@ class AlertsPlugin {
         alarm.Properties.Statistic = definition.statistic
       } else {
         alarm.Properties.ExtendedStatistic = definition.statistic
+        alarm.Properties.EvaluateLowSampleCountPercentile = definition.evaluateLowSampleCountPercentile
       }
     } else if (definition.type === 'anomalyDetection') {
       alarm = {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1145,6 +1145,7 @@ describe('#index', function () {
         evaluationPeriods: 1,
         comparisonOperator: 'GreaterThanThreshold',
         treatMissingData: 'breaching',
+        evaluateLowSampleCountPercentile: 'ignore',
       };
 
       const functionName = 'func-name';
@@ -1161,6 +1162,7 @@ describe('#index', function () {
           Threshold: definition.threshold,
           ExtendedStatistic: definition.statistic,
           Period: definition.period,
+          EvaluateLowSampleCountPercentile: definition.evaluateLowSampleCountPercentile,
           EvaluationPeriods: definition.evaluationPeriods,
           ComparisonOperator: definition.comparisonOperator,
           OKActions: ['ok-topic'],


### PR DESCRIPTION
## What did you implement:

Added support for the field `EvaluateLowSampleCountPercentile` when creating a percentile alarm.
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cw-alarm.html#cfn-cloudwatch-alarms-evaluatelowsamplecountpercentile

## How did you implement it:

When adding extended statistic (percentiles) added the field `EvaluateLowSampleCountPercentile` from `evaluateLowSampleCountPercentile` in the provided definition.

## How can we verify it:

Add: `evaluateLowSampleCountPercentile` field to a percentile alarm and deploy. The alarm's `Percentiles with low samples` property will be either 'ignore' or 'evaluate', depending on what you specify:

evaluateLowSampleCountPercentile = 'ignore' => ignore
evaluateLowSampleCountPercentile = 'evaluate' => evaluate
evaluateLowSampleCountPercentile = undefined => evaluate

![image](https://user-images.githubusercontent.com/7331813/100372172-de0f8d00-2fd6-11eb-837f-baaff376d9fe.png)

Examples:

Using the following config:
![image](https://user-images.githubusercontent.com/7331813/100372223-f089c680-2fd6-11eb-9195-39988464e328.png)

Before Change:
![image](https://user-images.githubusercontent.com/7331813/100372271-fed7e280-2fd6-11eb-8918-c7dc816ecc6c.png)

After Change:
![image](https://user-images.githubusercontent.com/7331813/100372292-06978700-2fd7-11eb-9a9e-c59db2ac4a2e.png)
![image](https://user-images.githubusercontent.com/7331813/100372586-786fd080-2fd7-11eb-9589-6fc8dc3f5e58.png)


## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources

