### PR TITLE
Support CloudFormation in SNS topic definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ custom:
 ```
 ## SNS Topics
 
-If topic name is specified, plugin assumes that topic does not exist and will create it. To use existing topics, specify ARNs or use Fn::ImportValue to use a topic exported with CloudFormation.
+If topic name is specified, plugin assumes that topic does not exist and will create it. To use existing topics, specify ARNs or use CloudFormation (e.g. Fn::ImportValue, Fn::Join and Ref) to refer to existing topics.
 
 #### ARN support
 
@@ -182,15 +182,37 @@ custom:
         topic: arn:aws:sns:${self:region}:${self::accountId}:monitoring-${opt:stage}
 ```
 
-#### Import support
+#### CloudFormation support
 
 ```yaml
-custom:
+custom: 
   alerts:
     topics:
       alarm:
         topic:
           Fn::ImportValue: ServiceMonitoring:monitoring-${opt:stage, 'dev'}
+      ok:
+        topic:
+          Fn::Join:
+            - ':'
+            - - arn:aws:sns
+              - Ref: AWS::Region
+              - Ref: AWS::AccountId
+              - example-ok-topic
+      insufficientData:
+        topic:
+          Ref: ExampleInsufficientdataTopic
+          
+
+resources:
+  Resources:
+    ExampleInsufficientdataTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: example-insufficientdata-topic
+        Subscription:
+          - Endpoint: me@example.com
+            Protocol: EMAIL
 ```
 
 ## SNS Notifications

--- a/src/index.js
+++ b/src/index.js
@@ -234,13 +234,14 @@ class AlertsPlugin {
   _addAlertTopic(key, topics, alertTopics, customAlarmName) {
     const topicConfig = topics[key];
     const isTopicConfigAnObject = _.isObject(topicConfig);
-    const isTopicConfigAnImport = isTopicConfigAnObject && topicConfig.topic['Fn::ImportValue'];
 
     const topic = isTopicConfigAnObject ? topicConfig.topic : topicConfig;
+    const isTopicAnObject = _.isObject(topic);
+
     const notifications = isTopicConfigAnObject ? topicConfig.notifications : [];
 
     if (topic) {
-      if (isTopicConfigAnImport || topic.indexOf('arn:') === 0) {
+      if (isTopicAnObject || topic.indexOf('arn:') === 0) {
         if (customAlarmName) {
           alertTopics[customAlarmName] = alertTopics[customAlarmName] || {};
           alertTopics[customAlarmName][key] = topic;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -575,6 +575,58 @@ describe('#index', function () {
         }
       });
     });
+
+    it('should not create SNS topic when an object including Fn::Join is passed under "topic"', () => {
+      const topic = {
+        'Fn::Join': [
+          ':',
+          [
+            'arn:aws:sns',
+            '${self:provider.region}',
+            {Ref: 'AWS::AccountId'},
+            'ok-topic'
+          ]
+        ],
+      }
+      const plugin = pluginFactory({
+        topics: {
+          ok: {
+            topic
+          }
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: topic
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
+
+    it('should not create SNS topic when an object including Ref is passed under "topic"', () => {
+      const topic = {
+        Ref: 'OkTopicLogicalId',
+      }
+      const plugin = pluginFactory({
+        topics: {
+          ok: {
+            topic
+          }
+        }
+      });
+
+      const config = plugin.getConfig();
+      const topics = plugin.compileAlertTopics(config);
+
+      expect(topics).toEqual({
+        ok: topic
+      });
+
+      expect(plugin.serverless.service.provider.compiledCloudFormationTemplate.Resources).toEqual({});
+    });
   });
 
   describe('#compileAlarms', () => {
@@ -866,7 +918,7 @@ describe('#index', function () {
         }
       });
 	});
-	
+
 	it('should skip alarms that are marked disabled', () => {
 		let config = {
 			definitions: {


### PR DESCRIPTION
## What did you implement:

Closes #54 and #68

Also includes functionality requested in #76

Currently only ARN or Fn::ImportValue are supported to specify an existing SNS topic for alarms. This PR extends support to any CloudFormation, e.g. Fn::Join and Ref.

Note: I already had a PR (#90) open for this fix, but it was closed due to incompatibility with newest version + inactivity.

## How can we verify it:

serverless.yml:

```yaml
custom: 
  alerts:
    topics:
      alarm:
        topic:
          Fn::ImportValue: ServiceMonitoring:monitoring-${opt:stage, 'dev'}
      ok:
        topic:
          Fn::Join:
            - ':'
            - - arn:aws:sns
              - Ref: AWS::Region
              - Ref: AWS::AccountId
              - example-ok-topic
      insufficientData:
        topic:
          Ref: ExampleInsufficientdataTopic
          

resources:
  Resources:
    ExampleInsufficientdataTopic:
      Type: AWS::SNS::Topic
      Properties:
        DisplayName: example-insufficientdata-topic
        Subscription:
          - Endpoint: me@example.com
            Protocol: EMAIL
```