### PR TITLE
Added option to create dashboards only in specific stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ dashboards: true
 
 Create a vertical dashboard:
 ```yaml
-dashboards: 'vertical'
+dashboards: vertical
 ```
 
 Create dashboards only in specified stages:
@@ -459,7 +459,7 @@ dashboards:
     - production
     - staging
   templates:
-    - 'default'
+    - default
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -438,6 +438,30 @@ stack. It will also be automatically removed if you remove your main stack.
 You can also enable the external stack on the command line with `sls deploy --alerts-external-stack`
 which is equivalent to adding `externalStack: true` to the configuration.
 
+## Dashboards
+
+The plugin can create dashboards automatically for basic metrics.
+
+Default setup for a single dashboard:
+```yaml
+dashboards: true
+```
+
+Create a vertical dashboard:
+```yaml
+dashboards: 'vertical'
+```
+
+Create dashboards only in specified stages:
+```yaml
+dashboards:
+  stages:
+    - production
+    - staging
+  templates:
+    - 'default'
+```
+
 ## License
 
 MIT © [A Cloud Guru](https://acloud.guru/)

--- a/src/index.js
+++ b/src/index.js
@@ -364,13 +364,23 @@ class AlertsPlugin {
     });
   }
 
-  getDashboardTemplates(configDashboards) {
+  getDashboardTemplates(configDashboards, stage) {
     const configType = typeof configDashboards;
 
     if (configType === 'boolean') {
       return ['default']
     } else if (configType === 'string') {
       return [configDashboards]
+    } else if (configType === 'object' && configDashboards.stages) {
+      if (configDashboards.stages.indexOf(stage) >= 0) {
+        if (configDashboards.templates) {
+          return [].concat(configDashboards.templates);
+        }
+        return ['default'];
+      }
+
+      this.serverless.cli.log(`Info: Not deploying dashboards on stage ${this.options.stage}`);
+      return [];
     } else {
       return [].concat(configDashboards);
     }
@@ -381,7 +391,7 @@ class AlertsPlugin {
     const provider = service.provider;
     const stage = this.options.stage;
     const region = this.options.region || provider.region;
-    const dashboardTemplates = this.getDashboardTemplates(configDashboards);
+    const dashboardTemplates = this.getDashboardTemplates(configDashboards, stage);
 
     const functions = this.serverless.service
       .getAllFunctions()

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -981,6 +981,35 @@ describe('#index', function () {
 	});
   });
 
+  describe('#getDashboardTemplates', () => {
+    const stage = "production";
+    const plugin = pluginFactory({}, stage);
+
+    it('should return default template if config is true', () => {
+      expect(plugin.getDashboardTemplates(true, stage)).toEqual(['default']);
+    });
+
+    it('should return given template if config is string', () => {
+      expect(plugin.getDashboardTemplates("vertical", stage)).toEqual(["vertical"]);
+    });
+
+    it('should return default template if config is object without templates defined', () => {
+      expect(plugin.getDashboardTemplates({ stages: ['production'] }, stage)).toEqual(["default"]);
+    });
+
+    it('should return defined template if config is object with stages and templates defined', () => {
+      expect(plugin.getDashboardTemplates({ stages: ['production'], templates: ['vertical'] }, stage)).toEqual(["vertical"]);
+    });
+
+    it('should return empty array if dashboard should not be deployed to this stage', () => {
+      expect(plugin.getDashboardTemplates({ stages: ['production'], templates: ['vertical'] }, 'dev')).toEqual([]);
+    });
+
+    it('should return all defined dashboards if config is an array', () => {
+      expect(plugin.getDashboardTemplates(['default', 'vertical'], stage)).toEqual(['default', 'vertical']);
+    });
+  });
+
   describe('#compileCloudWatchAlarms', () => {
     const stage = 'production';
     let plugin = null;


### PR DESCRIPTION
## What did you implement:

Implements #109 

Allows creation of dashboards only in specific stages.

## How did you implement it:

Added support for specifying dashboards option as follows:
```yaml
dashboards:
  stages:
    - production
    - staging
  templates:
    - default
    - vertical
```

## How can we verify it:

1. Modify the example project with following config:
```yaml
    dashboards:
      stages:
        - production
      templates:
        - default
 ```
2. Install updated plugin version `yarn add -D Marcholio/serverless-plugin-aws-alerts#master`
3. Run dry run deployment to `staging` stage. Verify that the stack file does not contain dashboard configuration and CLI outputs `Info: Not deploying dashboards on stage staging`
4. Run dry run deployment to `production` stage. Verify that the stack file contains dashboard configuration.

## Todos:

- [X] Write tests
- [X] Write documentation
- [X] Fix linting errors
- [X] Provide verification config/commands/resources

