### PR TITLE
Extend function defintion schema to properly support the alarms property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,14 @@ class AlertsPlugin {
     this.serverless = serverless;
     this.options = options;
 
+    serverless.configSchemaHandler.defineFunctionProperties('aws', {
+      properties: {
+        alarms: {
+          type: 'array',
+        },
+      },
+    });
+
     this.awsProvider = this.serverless.getProvider('aws');
     this.providerNaming = this.awsProvider.naming;
     this.naming = new Naming();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -41,6 +41,9 @@ const pluginFactory = (alarmsConfig, s) => {
         getStackName: () => `fooservice-${stage}`,
       },
     }),
+    configSchemaHandler: {
+      defineFunctionProperties: () => {},
+    },
   };
   return new Plugin(serverless, {
     stage,


### PR DESCRIPTION
## What did you implement:

Closes #167

## How did you implement it:

Extended the function schema per the Serverless docs: https://www.serverless.com/framework/docs/providers/aws/guide/plugins/#extending-validation-schema

## How can we verify it:

Add alarms to a function, and attempt `sls deploy` or `sls package`. You should no longer see Configuration warnings.


