### PR TITLE
chore: using lodash modules instead of the whole lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
   "author": "John McKim <john@acloud.guru>",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.10"
+    "lodash.merge": "^4.6.2",
+    "lodash.isstring": "^4.0.1",
+    "lodash.isobject": "^3.0.2",
+    "lodash.union": "^4.6.0",
+    "lodash.upperfirst": "^4.3.1"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^11.0.0",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,7 @@
+module.exports = {
+  merge: require('lodash.merge'),
+  isString: require('lodash.isstring'),
+  isObject: require('lodash.isobject'),
+  union: require('lodash.union'),
+  upperFirst: require('lodash.upperfirst'),
+};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
-const _ = require('lodash');
 const path = require('path');
+const { upperFirst } = require('./helpers');
 
 const Plugin = require('./index');
 
@@ -35,7 +35,7 @@ const pluginFactory = (alarmsConfig, s) => {
     },
     getProvider: () => ({
       naming: {
-        getLambdaLogicalId: (name) => `${_.upperFirst(name)}LambdaFunction`,
+        getLambdaLogicalId: (name) => `${upperFirst(name)}LambdaFunction`,
         getLogGroupLogicalId: (name) => name,
         getLogGroupName: (name) => `/aws/lambda/${name}`,
         getStackName: () => `fooservice-${stage}`,

--- a/src/naming.js
+++ b/src/naming.js
@@ -1,7 +1,7 @@
-const _ = require('lodash');
+const { upperFirst } = require('./helpers');
 
 const getNormalisedName = (name) =>
-  `${_.upperFirst(name.replace(/-/g, 'Dash').replace(/_/g, 'Underscore'))}`;
+  `${upperFirst(name.replace(/-/g, 'Dash').replace(/_/g, 'Underscore'))}`;
 
 class Naming {
   getAlarmCloudFormationRef(alarmName, prefix) {
@@ -12,11 +12,11 @@ class Naming {
   }
 
   getLogMetricCloudFormationRef(normalizedName, alarmName) {
-    return `${normalizedName}${_.upperFirst(alarmName)}LogMetricFilter`;
+    return `${normalizedName}${upperFirst(alarmName)}LogMetricFilter`;
   }
 
   getPatternMetricName(metricName, functionName) {
-    return `${_.upperFirst(metricName)}${functionName}`;
+    return `${upperFirst(metricName)}${functionName}`;
   }
 
   getDimensionsList(dimensionsList, funcRef, omitDefaultDimension) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2502,7 +2502,32 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash@^4.14.0, lodash@^4.17.10, lodash@^4.2.0:
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.union@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
+  integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
+
+lodash.upperfirst@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
+  integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
+
+lodash@^4.14.0, lodash@^4.2.0:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
 


### PR DESCRIPTION
## What did you implement:

Closes #12345

<!--
Using small lodash modules instead of the whole lib
-->

## How did you implement it:

<!--
Just removed the lodash lib and instead used it's modular libs for each use case. I created a helper.js to envelop those modular lodash functions, so they can be easily replaced by other implementations.
-->

## How can we verify it:

<!--
Nothing changes, all the tests and functionalities should keep working just as before.
-->

