### PR TITLE
fix: ensure to extend function schema only if method available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,18 @@ class AlertsPlugin {
     this.serverless = serverless;
     this.options = options;
 
-    serverless.configSchemaHandler.defineFunctionProperties('aws', {
-      properties: {
-        alarms: {
-          type: 'array',
+    if (
+      serverless.configSchemaHandler &&
+      serverless.configSchemaHandler.defineFunctionProperties
+    ) {
+      serverless.configSchemaHandler.defineFunctionProperties('aws', {
+        properties: {
+          alarms: {
+            type: 'array',
+          },
         },
-      },
-    });
+      });
+    }
 
     this.awsProvider = this.serverless.getProvider('aws');
     this.providerNaming = this.awsProvider.naming;


### PR DESCRIPTION
## What did you implement:

Closes #173

In order to not break the plugin for `serverless` in version lower than `2.10.0` where `defineFunctionProperties` was added (https://github.com/serverless/serverless/blob/master/CHANGELOG.md#2100-2020-11-03), we should check for it's existence before extending the schema

## How did you implement it:

Checking for the existence of `defineFunctionProperties` before calling it

## How can we verify it:

If you try to use plugin with `serverless` in version `<2.10.0`, it will fail as described in the linked issue. With this change, it will no longer fail.


## Todos:

[] Write tests
[] Write documentation
[x] Fix linting errors
[] Provide verification config/commands/resources

