### PR TITLE
feat: use custom namespace rather than stack-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ provider:
 
 plugins:
   - serverless-plugin-aws-alerts
-  
+
 custom:
   alerts:
     stages: # Optionally - select which stages to deploy alarms to
@@ -293,7 +293,7 @@ custom:
         pattern: '{$.level > 40}'
 ```
 
-> Note: For custom log metrics, namespace property will automatically be set to stack name (e.g. `fooservice-dev`).
+> Note: For custom log metrics, namespace property will automatically be set to stack name if it is not set in the definition(e.g. `fooservice-dev`).
 
 ## Custom Naming
 You can define custom naming template for the alarms. `nameTemplate` property under `alerts` configures naming template for all the alarms, while placing `nameTemplate` under alarm definition configures (overwrites) it for that specific alarm only. Naming template provides interpolation capabilities, where supported placeholders are:

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,14 @@ class AlertsPlugin {
     return this.getAlarms(alarms, definitions);
   }
 
+  getNameSpace(definition, stackName) {
+    if (!definition.namespace && definition.pattern) {
+      return stackName;
+    }
+
+    return definition.namespace;
+  }
+
   getAlarmCloudFormation(alertTopics, definition, functionName, functionRef) {
     if (!functionRef) {
       return;
@@ -140,7 +148,7 @@ class AlertsPlugin {
 
     const stackName = this.awsProvider.naming.getStackName();
 
-    const namespace = definition.pattern ? stackName : definition.namespace;
+    const namespace = this.getNameSpace(definition, stackName);
 
     const metricId = definition.pattern
       ? this.naming.getPatternMetricName(definition.metric, functionRef)
@@ -354,7 +362,8 @@ class AlertsPlugin {
     const logMetricCFRefOK = `${logMetricCFRefBase}OK`;
 
     const cfLogName = this.providerNaming.getLogGroupLogicalId(functionName);
-    const metricNamespace = this.providerNaming.getStackName();
+    const stackName = this.providerNaming.getStackName();
+    const metricNamespace = this.getNameSpace(alarm, stackName);
     const logGroupName = this.providerNaming.getLogGroupName(functionObj.name);
     const metricName = this.naming.getPatternMetricName(
       alarm.metric,


### PR DESCRIPTION
## What did you implement:
Allow using custom namespace value rather than the stack-name for alerts configured with patterns. 
Closes #142

## How did you implement it:
The implementation simply considers `namespace` value specified in the alert. The changes do not introduce any additional option
 
## How can we verify it:
You just need to add `namespace` to your alert definition then deploy to AWS. You should see your metric created under the specified namespace. 