### PR TITLE
adjusted regex for matching external stack errors when SLS_DEBUG is set

### DIFF
--- a/src/external-stack.js
+++ b/src/external-stack.js
@@ -217,7 +217,7 @@ class ExternalStack {
       })
       .then((response) => response.Stacks && response.Stacks[0])
       .catch((err) => {
-        if (err.message && err.message.match(/does not exist$/)) {
+        if (err.message && err.message.match(/stack with id .+ does not exist/i)) {
           // Stack doesn't exist yet
           return null;
         }
@@ -466,7 +466,7 @@ class ExternalStack {
       })
       .then(() => this.waitForExternalStack(externalStackName, 'update'))
       .then(null, (err) => {
-        if (err.message && err.message.match(/^No updates/)) {
+        if (err.message && err.message.match(/no updates are to be performed/i)) {
           // Stack is unchanged, ignore error
           this.serverless.cli.log(
             `External alert stack ${externalStackName} has not changed.`


### PR DESCRIPTION
## What did you implement:

<!--
Briefly describe the feature if no issue exists for this PR
-->

When running `sls deploy` with `SLS_DEBUG=*` errors messages have additional text and are not correctly detected by current regex. e.g

when run `sls deploy` without `SLS_DEBUG=*` error message is following:

```
Stack with id STACK_NAME does not exist
```

and when `SLS_DEBUG=*` is set it has following format:

```
ValidationError: Stack with id STACK_NAME does not exist\nSTACK_TRACE
```

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

I removed requirement for matching a beginning or ending of string and added some extra text to prevent false positive matching.

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->

Set `externalStack` to true

```
custom:
  alerts:
    externalStack: true
    stages:
      - prod
      - test
      - dev
```

Run `sls deploy` with and without `SLS_DEBUG=*` set for stage present in the list and for stage not present in the list.
