### PR TITLE
Fixed misleading Metric Log Filters code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ custom:
       barExceptions:
         metric: barExceptions
         threshold: 0
-        statistic: Minimum
+        statistic: Sum
         period: 60
         evaluationPeriods: 1
         comparisonOperator: GreaterThanThreshold


### PR DESCRIPTION
Changed statistic from "Minimum" to "Sum" so that the alarm is triggered as explained when the log contains a line with the pattern "exception Bar".