### PR TITLE
feat: add support for notifications on existing sns topics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,6 +296,28 @@ class AlertsPlugin {
         } else {
           alertTopics[key] = topic;
         }
+
+        const subscriptions = (notifications || []).reduce((memo, n) => {
+          const nameSuffix = n.name || '';
+          const cfRef = `AwsAlerts${upperFirst(key)}${upperFirst(n.protocol)}${nameSuffix}Subscription`;
+
+          if (memo[cfRef]) {
+            throw new Error('Subscription with the same protocol already exists! Use the name property to uniquely identify it');
+          }
+
+          return Object.assign(memo, {
+            [cfRef]: {
+              Type: 'AWS::SNS::Subscription',
+              Properties: {
+                TopicArn: topic,
+                Protocol: n.protocol,
+                Endpoint: n.endpoint,
+              },
+            },
+          });
+        }, {});
+
+        this.addCfResources(subscriptions);
       } else {
         const cfRef = `AwsAlerts${
           customAlarmName ? upperFirst(customAlarmName) : ''


### PR DESCRIPTION
## What did you implement:

Closes #119

## How did you implement it:

This adds new resources for notifications if there's no Topic resource being created.

## How can we verify it:

I added some basic tests.  I don't think documentation is necessary per se because this is actually what I think most people expected to happen based on the current documentation.

I tested it on my project and it worked. To test it, you just need to have something like:


```js
topics: {
    alarm: {
        topic: {
            'Fn::ImportValue': 'monitoring-topic-arn',
        },
        // without this PR, this section just gets ignored and no subscriptions are created.
        notifications: [{
            protocol: 'lambda',
            endpoint: {
                'Fn::GetAtt': 'LambdaFunction.Arn',
            },
        }],
    },
},
```


## Todos:

[x] Write tests
[x] Write documentation
[x] Fix linting errors
[x] Provide verification config/commands/resources

