### PR TITLE
Move 'husky install' from 'postinstall' to 'prepare' 

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint-fix": "eslint . --fix",
     "test": "jest --coverage",
     "test:watch": "jest --watch",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },


### PR DESCRIPTION
npm7 can't handle husky being in the 'postinstall' step. Husky documentation states 'husky install' should be run from the 'prepare' script.

Husky docs: https://github.com/typicode/husky

## What did you implement:

Fixes:
•  https://github.com/ACloudGuru/serverless-plugin-aws-alerts/issues/191
•  https://github.com/ACloudGuru/serverless-plugin-aws-alerts/issues/176

## How did you implement it:

Moved `husky install` from the `postinstall` script to the `prepare` script.

## How can we verify it:

Attempt to make a commit, publish or install this module in a project that does not already have husky installed while using npm6 and npm 7.


