### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "^2.2.1"
   },
   "peerDependencies": {
-    "serverless": "^2.4.0"
+    "serverless": "^2.4.0 || 3"
   },
   "engines": {
     "node": ">=8.10.0"


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good to whitelist v3 of the Framework in peer dependencies section