### PR TITLE
Add support for external API Gateway in the dashboards #215

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,14 @@ dashboards:
     - default
 ```
 
+Using external API Gateway:
+```yaml
+alarms:
+  dashboards: true
+  dashboardConfig:
+    apiName: 'my-api-name-here'
+```
+
 ## License
 
 MIT © [A Cloud Guru](https://acloud.guru/)

--- a/src/dashboards/index.js
+++ b/src/dashboards/index.js
@@ -5,7 +5,14 @@ const dashboards = {
   vertical: require('./configs/vertical.json'),
 };
 
-const createDashboard = (service, stage, region, functions, name) => {
+const createDashboard = (
+  service,
+  stage,
+  region,
+  functions,
+  name,
+  dashboardConfig
+) => {
   const dashboard = dashboards[name];
 
   if (!dashboard) {
@@ -21,6 +28,7 @@ const createDashboard = (service, stage, region, functions, name) => {
       coordinates: w.coordinates,
       title: w.title,
       functions,
+      dashboardConfig,
     };
 
     return widget.createWidget(config);

--- a/src/dashboards/widgets/api-gw/latency/numbers.js
+++ b/src/dashboards/widgets/api-gw/latency/numbers.js
@@ -1,5 +1,6 @@
 const createWidget = (config) => {
-  const apiName = `${config.stage}-${config.service}`;
+  const apiName =
+    config.dashboardConfig.apiName ?? `${config.stage}-${config.service}`;
 
   const widget = {
     type: 'metric',

--- a/src/dashboards/widgets/api-gw/latency/time-series.js
+++ b/src/dashboards/widgets/api-gw/latency/time-series.js
@@ -1,5 +1,6 @@
 const createWidget = (config) => {
-  const apiName = `${config.stage}-${config.service}`;
+  const apiName =
+    config.dashboardConfig.apiName ?? `${config.stage}-${config.service}`;
 
   const widget = {
     type: 'metric',

--- a/src/dashboards/widgets/api-gw/requests/numbers.js
+++ b/src/dashboards/widgets/api-gw/requests/numbers.js
@@ -1,5 +1,6 @@
 const createWidget = (config) => {
-  const apiName = `${config.stage}-${config.service}`;
+  const apiName =
+    config.dashboardConfig.apiName ?? `${config.stage}-${config.service}`;
 
   const widget = {
     type: 'metric',

--- a/src/dashboards/widgets/api-gw/requests/time-series.js
+++ b/src/dashboards/widgets/api-gw/requests/time-series.js
@@ -1,5 +1,6 @@
 const createWidget = (config) => {
-  const apiName = `${config.stage}-${config.service}`;
+  const apiName =
+    config.dashboardConfig.apiName ?? `${config.stage}-${config.service}`;
 
   const widget = {
     type: 'metric',

--- a/src/index.js
+++ b/src/index.js
@@ -482,6 +482,7 @@ class AlertsPlugin {
     const provider = service.provider;
     const stage = this.options.stage;
     const region = this.options.region || provider.region;
+    const config = this.getConfig();
     const dashboardTemplates = this.getDashboardTemplates(
       configDashboards,
       stage
@@ -497,7 +498,8 @@ class AlertsPlugin {
         stage,
         region,
         functions,
-        d
+        d,
+        config.dashboardConfig ?? {}
       );
 
       const cfResource =


### PR DESCRIPTION
## What did you implement:

Closes #215

This PR adds support for external API Gateway in the dashboards, currently, this plugin uses the stage and service name to build the API gateway name.

When you have an external API Gateway the dashboard widgets for API metrics shows always empty if the API Gateway name is different.

## How did you implement it:

To solve this problem I added a new config property named `dashboardConfig` as a group and a property named `apiName` and if the value is present use the custom name.

config example:

```yaml
custom:
  alerts:
    dashboards: true
    dashboardConfig: 
      apiName: 'my-custom-api-gateway-name'
```

## How can we verify it:

I published a version in my personal npm organization with these changes 

https://www.npmjs.com/package/@slslv/serverless-plugin-aws-alerts

