### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Serverless plugin to easily add CloudWatch alarms to functions
 
 ## Installation
 ```bash
-npm i serverless-plugin-aws-alerts
+npm i serverless-plugin-aws-alerts --save-dev
 
 OR
 


### PR DESCRIPTION
By adding as a dev (package time) dependency, does not drag the whole Serverless framework, and all of it's dependencies, into the deployment package.

Closes #218 

